### PR TITLE
KTSEサーバーの認証実装追加

### DIFF
--- a/ktcp/model/src/commonMain/kotlin/net/kigawa/keruta/ktcp/model/KtcpServerEntrypoints.kt
+++ b/ktcp/model/src/commonMain/kotlin/net/kigawa/keruta/ktcp/model/KtcpServerEntrypoints.kt
@@ -1,8 +1,6 @@
 package net.kigawa.keruta.ktcp.model
 
 import net.kigawa.keruta.ktcp.model.authenticate.AuthenticateEntrypoint
-import net.kigawa.keruta.ktcp.model.err.ErrCode
-import net.kigawa.keruta.ktcp.model.msg.KtcpUnknownMsg
 import net.kigawa.keruta.ktcp.model.msg.UnknownArg
 import net.kigawa.kodel.api.entrypoint.EntrypointGroupBase
 import net.kigawa.kodel.api.entrypoint.EntrypointInfo
@@ -29,9 +27,11 @@ class KtcpServerEntrypoints<C>(
         input: UnknownArg,
     ): Res<Unit, EntrypointNotFoundErr> {
         logger.error("not found entrypoint: $input")
-        return Res.Err(EntrypointNotFoundErr(
-            message = "No entrypoint found for message type: $input",
-        ))
+        return Res.Err(
+            EntrypointNotFoundErr(
+                message = "No entrypoint found for message type: $input",
+            )
+        )
     }
 
 

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
@@ -5,12 +5,10 @@ import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.channels.consumeEach
-import net.kigawa.keruta.ktcp.model.msg.UnknownArg
 import net.kigawa.keruta.ktcp.model.serialize.JsonMsgSerializer
 import net.kigawa.keruta.ktcp.server.KtcpServer
 import net.kigawa.keruta.ktcp.server.KtcpSession
 import net.kigawa.keruta.ktcp.server.ServerCtx
-import net.kigawa.keruta.ktse.reader.DecodeFrameErr
 import net.kigawa.kodel.api.err.Res
 import net.kigawa.kodel.api.log.getLogger
 import net.kigawa.kodel.api.log.traceignore.error
@@ -35,19 +33,21 @@ object KerutaTaskServer {
         KtcpSession.startSession(WebsocketConnection(this@webSocket)) { session ->
             val jsonSerializer = JsonMsgSerializer()
             incoming.consumeEach { frame ->
-                receive(frame, ServerCtx(session,jsonSerializer))
+                receive(frame, ServerCtx(session, jsonSerializer))
             }
         }
     }
 
     suspend fun receive(frame: Frame, ctx: ServerCtx) = when (
-        val msg = WebsocketUnknownArg.fromFrame(frame,ctx)
+        val msg = ReceiveUnknownArg.fromFrame(frame, ctx)
     ) {
         is Res.Err<*, *> -> {
             logger.error("Failed to decode frame", msg.err)
-                ctx.session.recordErr()
+            ctx.session.recordErr()
         }
 
-        is Res.Ok<*, *> -> TODO()
+        is Res.Ok<ReceiveUnknownArg, *> -> {
+            ktcpServer.ktcpServerEntrypoints.access(msg.value, ctx)
+        }
     }
 }

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveAuthenticateArg.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveAuthenticateArg.kt
@@ -1,0 +1,6 @@
+package net.kigawa.keruta.ktse
+
+import net.kigawa.keruta.ktcp.model.authenticate.AuthenticateArg
+
+class ReceiveAuthenticateArg: AuthenticateArg {
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveGenericErrArg.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveGenericErrArg.kt
@@ -1,0 +1,6 @@
+package net.kigawa.keruta.ktse
+
+import net.kigawa.keruta.ktcp.model.err.GenericErrArg
+
+class ReceiveGenericErrArg: GenericErrArg {
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveUnknownArg.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/ReceiveUnknownArg.kt
@@ -1,7 +1,11 @@
 package net.kigawa.keruta.ktse
 
 import io.ktor.websocket.*
+import net.kigawa.keruta.ktcp.model.authenticate.AuthenticateArg
+import net.kigawa.keruta.ktcp.model.err.GenericErrArg
 import net.kigawa.keruta.ktcp.model.msg.KtcpUnknownMsg
+import net.kigawa.keruta.ktcp.model.msg.MsgType
+import net.kigawa.keruta.ktcp.model.msg.UnknownArg
 import net.kigawa.keruta.ktcp.model.serialize.DeserializeErr
 import net.kigawa.keruta.ktcp.model.serialize.deserialize
 import net.kigawa.keruta.ktcp.server.ServerCtx
@@ -10,17 +14,27 @@ import net.kigawa.keruta.ktse.reader.DeserializeDecodeFrameErr
 import net.kigawa.keruta.ktse.reader.InvalidTypeDecodeFrameErr
 import net.kigawa.kodel.api.err.Res
 
-class WebsocketUnknownArg(
+class ReceiveUnknownArg(
     val msg: KtcpUnknownMsg,
-) {
+): UnknownArg {
+    override fun tryToGenericError(): GenericErrArg? {
+        if (msg.type != MsgType.GENERIC_ERROR) return null
+        return ReceiveGenericErrArg()
+    }
+
+    override fun tryToAuthenticate(): AuthenticateArg? {
+        if (msg.type != MsgType.AUTHENTICATE) return null
+        return ReceiveAuthenticateArg()
+    }
+
     companion object {
-        fun fromFrame(frame: Frame, ctx: ServerCtx): Res<WebsocketUnknownArg, DecodeFrameErr> {
+        fun fromFrame(frame: Frame, ctx: ServerCtx): Res<ReceiveUnknownArg, DecodeFrameErr> {
             if (frame !is Frame.Text) return Res.Err(InvalidTypeDecodeFrameErr())
             return when (
                 val msg = ctx.serializer.deserialize<KtcpUnknownMsg>(frame.readText())
             ) {
                 is Res.Err<*, DeserializeErr> -> msg.mapErr { DeserializeDecodeFrameErr(it) }
-                is Res.Ok<KtcpUnknownMsg, *> -> Res.Ok(WebsocketUnknownArg(msg.value))
+                is Res.Ok<KtcpUnknownMsg, *> -> Res.Ok(ReceiveUnknownArg(msg.value))
             }
         }
     }


### PR DESCRIPTION
# KTSEサーバーの認証実装追加

## 概要
KTSEサーバーで認証機能を実装するための新しい受信引数クラスを追加しました。

## 背景・目的
KTSEサーバーの認証機能を拡張し、より安全な通信を実現するため、この変更が必要です。

## 変更内容
- `ReceiveAuthenticateArg.kt` の新規作成
- `ReceiveGenericErrArg.kt` の新規作成  
- `WebsocketUnknownArg.kt` を `ReceiveUnknownArg.kt` にリネーム
- 関連するサーバーおよびモデルクラスの修正

## 確認方法
1. プロジェクトをビルドする
2. テストを実行して認証機能が正しく動作することを確認する

## その他
特になし