### PR TITLE
feat: Renovateのpatch/minor更新に自動マージ設定を追加

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,11 @@
     ],
     "rebaseWhen": "behind-base-branch",
     "prConcurrentLimit": 0,
-    "prHourlyLimit": 0
+    "prHourlyLimit": 0,
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true
+        }
+    ]
 }


### PR DESCRIPTION
# feat: Renovateのpatch/minor更新に自動マージ設定を追加

## 概要
Renovate Botの設定に、patch/minorバージョンの更新を自動マージする機能を追加しました。

## 背景・目的
現在、Renovate Botによる依存関係の更新は全て手動レビューが必要な状態です。しかし、patch/minorレベルの更新は通常破壊的変更を含まないため、これらを自動的にマージすることで、以下のメリットが得られます：

- 手動レビューの負担軽減
- 依存関係を常に最新の状態に保つ
- セキュリティパッチの迅速な適用

## 変更内容
- `.github/renovate.json`に`packageRules`セクションを追加
- `matchUpdateTypes`で`patch`と`minor`を指定
- `automerge: true`を設定し、該当する更新を自動マージするように構成

```json
"packageRules": [
    {
        "matchUpdateTypes": ["patch", "minor"],
        "automerge": true
    }
]
```

## 確認方法
1. この設定がマージされた後、Renovate BotがPRを作成した際に、patch/minor更新は自動的にマージされることを確認
2. major更新は従来通り手動レビューが必要なことを確認

## その他
- majorバージョンの更新は引き続き手動レビューが必要です
- automerge機能はGitHubリポジトリの設定でも有効化されている必要があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)