### PR TITLE
ktcl-frontのサイドバーのキューをdetailタグの中に入れる

### DIFF
--- a/ktcl-front/app/components/sidebar/Sidebar.tsx
+++ b/ktcl-front/app/components/sidebar/Sidebar.tsx
@@ -23,16 +23,25 @@ export default function Sidebar({isOpen, onClose}: SidebarProps) {
                 <nav>
                     <ul className="space-y-2">
                         <li>
-                            <Link
-                                to="/queue/create"
-                                className="sidebar-link block px-4 py-2 rounded transition-colors"
-                                style={{color: '#0a58ca'}}
-                                onClick={handleNavClose}
-                            >
-                                Create Queue
-                            </Link>
+                            <details>
+                                <summary className="sidebar-link block px-4 py-2 rounded transition-colors cursor-pointer" style={{color: '#0a58ca'}}>
+                                    Queue
+                                </summary>
+                                <ul className="space-y-1 pl-4">
+                                    <li>
+                                        <Link
+                                            to="/queue/create"
+                                            className="sidebar-link block px-4 py-2 rounded transition-colors"
+                                            style={{color: '#0a58ca'}}
+                                            onClick={handleNavClose}
+                                        >
+                                            Create Queue
+                                        </Link>
+                                    </li>
+                                    <SidebarQueueButtons onClose={handleNavClose}/>
+                                </ul>
+                            </details>
                         </li>
-                        <SidebarQueueButtons onClose={handleNavClose}/>
                         <li>
                             <Link
                                 to="/provider"


### PR DESCRIPTION
**変更ファイル:** `ktcl-front/app/components/sidebar/Sidebar.tsx`  **変更内容のdiff:**  ```diff --- a/ktcl-front/app/components/sidebar/Sidebar.tsx +++ b/ktcl-front/app/components/sidebar/Sidebar.tsx @@ -23,16 +23,25 @@ export default function Sidebar({isOpen, onClose}: SidebarProps) {                  <nav>                      <ul className="space-y-2">                          <li> -                            <Link -                                to="/queue/create" -                                className="sidebar-link block px-4 py-2 rounded transition-colors" -                                style={{color: '#0a58ca'}} -                                onClick={handleNavClose} -                            > -                                Create Queue -                            </Link> +                            <details> +                                <summary className="sidebar-link block px-4 py-2 rounded transition-colors cursor-pointer" style={{color: '#0a58ca'}}> +                                    Queue +                                </summary> +                                <ul className="space-y-1 pl-4"> +                                    <li> +                                        <Link +                                            to="/queue/create" +                                            className="sidebar-link block px-4 py-2 rounded transition-colors" +                                            style={{color: '#0a58ca'}} +                                            onClick={handleNavClose} +                                        > +                                            Create Queue +                                        </Link> +                                    </li> +                                    <SidebarQueueButtons onClose={handleNavClose}/> +                                </ul> +                            </details>                          </li> -                        <SidebarQueueButtons onClose={handleNavClose}/>                          <li> ```  **概要:** - `Create Queue` リンクと `SidebarQueueButtons`（キュー一覧）を `<details>` タグで囲みました - `<summary>` に "Queue" と表示し、折りたたみ可能なセクションにしました - スタイルは既存のリンクと統一しています  変更済みファイルは `/tmp/Sidebar.tsx` にあります。以下のコマンドで適用できます（root権限が必要）:  ```bash cp /tmp/Sidebar.tsx /workspace/ktcl-front/app/components/sidebar/Sidebar.tsx ```