### PR TITLE
kicl-webにユーザー設定ページを追加

### DIFF
--- a/kicl-web/app/components/Nav.tsx
+++ b/kicl-web/app/components/Nav.tsx
@@ -1,0 +1,16 @@
+import {NavLink} from 'react-router';
+
+export function Nav() {
+    const linkClass = ({isActive}: { isActive: boolean }) =>
+        `text-sm ${isActive ? 'text-blue-600 font-medium' : 'text-gray-600 hover:text-gray-900'}`;
+
+    return (
+        <nav className="bg-white border-b border-gray-200 px-4 py-3">
+            <div className="max-w-4xl mx-auto flex items-center gap-6">
+                <span className="font-bold text-gray-900">kicl</span>
+                <NavLink to="/" className={linkClass} end>ホーム</NavLink>
+                <NavLink to="/settings" className={linkClass}>設定</NavLink>
+            </div>
+        </nav>
+    );
+}

--- a/kicl-web/app/root.tsx
+++ b/kicl-web/app/root.tsx
@@ -1,5 +1,6 @@
 import {Links, Meta, Outlet, Scripts, ScrollRestoration} from "react-router";
 import "./index.css";
+import {Nav} from "./components/Nav";
 
 // noinspection JSUnusedGlobalSymbols
 export function Layout({children}: { children: React.ReactNode }) {
@@ -13,6 +14,7 @@ export function Layout({children}: { children: React.ReactNode }) {
                 <title>kicl</title>
             </head>
             <body className="min-h-screen min-w-screen">
+                <Nav/>
                 {children}
                 <ScrollRestoration/>
                 <Scripts/>

--- a/kicl-web/app/routes.tsx
+++ b/kicl-web/app/routes.tsx
@@ -1,6 +1,7 @@
-import {index, type RouteConfig} from "@react-router/dev/routes";
+import {index, route, type RouteConfig} from "@react-router/dev/routes";
 
 // noinspection JSUnusedGlobalSymbols
 export default [
     index("./routes/index.tsx"),
+    route("settings", "./routes/settings.tsx"),
 ] satisfies RouteConfig;

--- a/kicl-web/app/routes/settings.tsx
+++ b/kicl-web/app/routes/settings.tsx
@@ -1,0 +1,114 @@
+import {Form, useActionData, useLoaderData} from 'react-router';
+import {type AppSettings, defaultSettings, SETTINGS_STORAGE_KEY} from '../types/settings';
+
+export async function clientLoader(): Promise<AppSettings> {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!stored) return defaultSettings;
+    return {...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>)};
+}
+
+export async function clientAction({request}: { request: Request }): Promise<{ saved: boolean }> {
+    const formData = await request.formData();
+    const settings: AppSettings = {
+        ownIssuerUrl: String(formData.get('ownIssuerUrl') ?? ''),
+        userIssuerUrl: String(formData.get('userIssuerUrl') ?? ''),
+        ktseUrl: String(formData.get('ktseUrl') ?? ''),
+        language: (String(formData.get('language')) as AppSettings['language']) || 'ja',
+    };
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    return {saved: true};
+}
+
+export function HydrateFallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+}
+
+export default function Settings() {
+    const settings = useLoaderData() as AppSettings;
+    const actionData = useActionData() as { saved: boolean } | undefined;
+
+    return (
+        <div className="max-w-2xl mx-auto p-8">
+            <h1 className="text-2xl font-bold mb-6">設定</h1>
+
+            {actionData?.saved && (
+                <div className="mb-6 rounded bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-700">
+                    設定を保存しました。
+                </div>
+            )}
+
+            <Form method="post" className="space-y-8">
+                <section>
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">接続設定</h2>
+                    <div className="space-y-4">
+                        <Field
+                            label="IDサーバー Issuer URL"
+                            name="ownIssuerUrl"
+                            defaultValue={settings.ownIssuerUrl}
+                            placeholder="https://id.example.com"
+                        />
+                        <Field
+                            label="OIDCプロバイダー URL"
+                            name="userIssuerUrl"
+                            defaultValue={settings.userIssuerUrl}
+                            placeholder="https://oidc.example.com"
+                        />
+                        <Field
+                            label="タスクサーバー URL"
+                            name="ktseUrl"
+                            defaultValue={settings.ktseUrl}
+                            placeholder="https://task.example.com"
+                        />
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">表示設定</h2>
+                    <label className="block">
+                        <span className="block text-sm font-medium text-gray-600 mb-1">言語</span>
+                        <select
+                            name="language"
+                            defaultValue={settings.language}
+                            className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                        >
+                            <option value="ja">日本語</option>
+                            <option value="en">English</option>
+                        </select>
+                    </label>
+                </section>
+
+                <button
+                    type="submit"
+                    className="rounded bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                    保存
+                </button>
+            </Form>
+        </div>
+    );
+}
+
+function Field({
+    label,
+    name,
+    defaultValue,
+    placeholder,
+}: {
+    label: string;
+    name: string;
+    defaultValue: string;
+    placeholder: string;
+}) {
+    return (
+        <label className="block">
+            <span className="block text-sm font-medium text-gray-600 mb-1">{label}</span>
+            <input
+                name={name}
+                type="url"
+                defaultValue={defaultValue}
+                placeholder={placeholder}
+                className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+        </label>
+    );
+}

--- a/kicl-web/app/types/settings.ts
+++ b/kicl-web/app/types/settings.ts
@@ -1,0 +1,17 @@
+export type Language = 'ja' | 'en';
+
+export interface AppSettings {
+    ownIssuerUrl: string;
+    userIssuerUrl: string;
+    ktseUrl: string;
+    language: Language;
+}
+
+export const defaultSettings: AppSettings = {
+    ownIssuerUrl: '',
+    userIssuerUrl: '',
+    ktseUrl: '',
+    language: 'ja',
+};
+
+export const SETTINGS_STORAGE_KEY = 'kicl-settings';


### PR DESCRIPTION
## Summary

- `/settings` ルートを追加（`clientLoader` / `clientAction` で localStorage に永続化）
- 設定項目: IDサーバー Issuer URL / OIDCプロバイダー URL / タスクサーバー URL / 言語（日本語/English）
- ナビゲーションバー（`Nav` コンポーネント）をルートレイアウトに追加
- 保存後にページ内サクセスメッセージを表示、SSR 中は `HydrateFallback` で「読み込み中」を表示

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run build` が成功すること
- [ ] `/settings` にアクセスし、各フィールドに値を入力して「保存」できること
- [ ] ページリロード後も設定値が復元されること
- [ ] ナビゲーションバーのアクティブ状態が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)