### PR TITLE
stg環境のサーバー構築: K8sマニフェストとGitHub Actionsワークフロー追加

### DIFF
--- a/.github/workflows/kicl-web-stg.yml
+++ b/.github/workflows/kicl-web-stg.yml
@@ -1,0 +1,25 @@
+name: kicl-web-stg
+on:
+  push:
+    paths:
+      - 'kicl-web/**'
+      - 'kicl/**'
+      - Dockerfile_kicl_web
+      - .github/workflows/kicl-web-stg.yml
+    branches:
+      - staging
+
+jobs:
+  kicl-web:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      HARBOR_PASS: ${{ secrets.HARBOR_PASS }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      name: kicl-web
+      manifestFile: ./keruta/stg/kicl-web.yaml
+      harborProject: "private"
+      repository: "kigawa-net/kigawa-net-k8s"
+      dockerFile: './Dockerfile_kicl_web'
+      yamlPath: 'select(documentIndex == 0).spec.template.spec.containers[0].image'
+      gradleTask: ':kicl:kicl-domain:jsBrowserProductionLibraryDistribution :kicl:kicl-usecase:jsBrowserProductionLibraryDistribution'

--- a/.github/workflows/ktcl-claudecode-stg.yml
+++ b/.github/workflows/ktcl-claudecode-stg.yml
@@ -1,0 +1,21 @@
+name: ktcl-claudecode-stg
+on:
+  push:
+    paths:
+      - 'ktcl-claudecode/**'
+    branches:
+      - staging
+
+jobs:
+  ktcl-claudecode:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      HARBOR_PASS: ${{ secrets.HARBOR_PASS }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      name: ktcl-claudecode
+      manifestFile: ""
+      harborProject: "library"
+      repository: "kigawa-net/kigawa-net-k8s"
+      dockerFile: './Dockerfile_ktcl_claudecode'
+      gradleTask: ':ktcl-claudecode:build -x test'

--- a/.github/workflows/ktcl-front-stg.yml
+++ b/.github/workflows/ktcl-front-stg.yml
@@ -1,0 +1,37 @@
+name: ktcl-front-stg
+on:
+  push:
+    paths:
+      - 'ktcl-front/**'
+    branches:
+      - staging
+
+jobs:
+  ktcl-front:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      HARBOR_PASS: ${{ secrets.HARBOR_PASS }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      name: ktcl-front
+      manifestFile: ./keruta/stg/ktcl-front.yaml
+      harborProject: "private"
+      repository: "kigawa-net/kigawa-net-k8s"
+      dockerFile: './Dockerfile_ktcl_front'
+      yamlPath: 'select(documentIndex == 0).spec.template.spec.containers[0].image'
+      buildArgs: >
+        {
+          "VITE_WEBSOCKET_URL": "wss://ktse-stg.kigawa.net/ws/ktcp",
+          "VITE_USER_ISSUER": "https://user.kigawa.net/realms/develop",
+          "VITE_USER_CLIENT_ID": "keruta",
+          "VITE_KEYCLOAK_URL": "https://user.kigawa.net/",
+          "VITE_KEYCLOAK_REALM": "develop",
+          "VITE_KEYCLOAK_CLIENT_ID": "keruta",
+          "VITE_PROVIDER_PRESETS": "[
+            {
+              \"name\": \"ktcl-k8s\",
+              \"issuer\": \"https://ktcl-k8s-stg.kigawa.net\",
+              \"description\": \"ktcl-k8s\"
+            }
+          ]"
+        }

--- a/.github/workflows/ktcl-k8s-stg.yml
+++ b/.github/workflows/ktcl-k8s-stg.yml
@@ -1,0 +1,22 @@
+name: ktcl-k8s-stg
+on:
+  push:
+    paths:
+      - 'ktcl-k8s/**'
+    branches:
+      - staging
+
+jobs:
+  ktcl-k8s:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      HARBOR_PASS: ${{ secrets.HARBOR_PASS }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      name: ktcl-k8s
+      manifestFile: ./keruta/stg/ktcl-k8s.yaml
+      harborProject: "library"
+      repository: "kigawa-net/kigawa-net-k8s"
+      dockerFile: './Dockerfile_ktcl_k8s'
+      gradleTask: ':ktcl-k8s:shadowJar -x test'
+      yamlPath: 'select(documentIndex == 0).spec.template.spec.containers[0].image'

--- a/.github/workflows/ktse-stg.yml
+++ b/.github/workflows/ktse-stg.yml
@@ -1,0 +1,22 @@
+name: ktse-stg
+on:
+  push:
+    paths:
+      - 'ktse/**'
+    branches:
+      - staging
+
+jobs:
+  ktse:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      HARBOR_PASS: ${{ secrets.HARBOR_PASS }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+    with:
+      name: ktse
+      manifestFile: ./keruta/stg/ktse.yaml
+      harborProject: "library"
+      repository: "kigawa-net/kigawa-net-k8s"
+      dockerFile: './Dockerfile_ktse'
+      gradleTask: ':ktse:shadowJar -x test'
+      yamlPath: 'select(documentIndex == 0).spec.template.spec.containers[0].image'


### PR DESCRIPTION
## Summary

- `kigawa-net-k8s/keruta/stg/` にstagingネームスペース用K8sマニフェストを追加（ns, sandbox, ktse, ktcl-k8s, ktcl-front, kicl-web, ingress, mariadb-ktse, mariadb-k8s, zookeeper-ktse）
- `staging`ブランチへのpushでビルド・デプロイするGitHub Actionsワークフロー5本を追加（ktse/ktcl-k8s/ktcl-front/kicl-web/ktcl-claudecode）

## 設定値

- Namespace: `kigawa-net-keruta-stg`
- Sandbox: `kigawa-net-keruta-stg-sandbox`
- Domains: `ktse-stg.kigawa.net`, `keruta-stg.kigawa.net`, `ktcl-k8s-stg.kigawa.net`, `kicl-web-stg.kigawa.net`

## TODO

- `# TODO: stg用のBitwarden SecretIDに差し替える` となっている各マニフェストのBitwarden SecretIDをstg用に差し替える
- ArgoCDにstg環境のApplicationリソースを追加する
- `staging` ブランチの作成

## Test plan

- [ ] K8sマニフェストのdry-run: `kubectl apply --dry-run=client -f kigawa-net-k8s/keruta/stg/`
- [ ] stagingブランチへpushしてワークフローが正常に起動することを確認
- [ ] stg環境のURLにアクセスして各サービスが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)