### PR TITLE
fix(kicl-web): トップページでナビゲーションが表示されない問題を修正

### DIFF
--- a/kicl-web/app/routes.tsx
+++ b/kicl-web/app/routes.tsx
@@ -2,6 +2,12 @@ import {index, route, type RouteConfig} from "@react-router/dev/routes";
 
 // noinspection JSUnusedGlobalSymbols
 export default [
-    index("./routes/index.tsx"),
-    route("settings", "./routes/settings.tsx"),
+    {
+        id: "root",
+        file: "root.tsx",
+        children: [
+            index("./routes/index.tsx"),
+            route("settings", "./routes/settings.tsx"),
+        ],
+    },
 ] satisfies RouteConfig;


### PR DESCRIPTION
## 概要
トップページ（`/`）でナビゲーションバーが表示されない問題を修正しました。

## 原因
`routes.tsx` でルート定義が配列のフラットな形式だったため、`root.tsx` の `Layout` 関数がインデックスルートに適用されていませんでした。

## 修正内容
`routes.tsx` で `root.tsx` を明示的な親ルートとして設定し、インデックスルートと設定ルートをその子ルートとしてネストしました。

```diff
 export default [
-    index("./routes/index.tsx"),
-    route("settings", "./routes/settings.tsx"),
+    {
+        id: "root",
+        file: "root.tsx",
+        children: [
+            index("./routes/index.tsx"),
+            route("settings", "./routes/settings.tsx"),
+        ],
+    },
 ] satisfies RouteConfig;
```

## 影響範囲
- 全ページで `Nav` コンポーネントが正しく表示されるようになる