### PR TITLE
fix(kicl-web): ルートエラー発生時もナビゲーションを表示し、routes設定を修正

### DIFF
--- a/kicl-web/app/root.tsx
+++ b/kicl-web/app/root.tsx
@@ -26,3 +26,22 @@ export function Layout({children}: { children: React.ReactNode }) {
 export default function App() {
     return <Outlet/>;
 }
+
+export function ErrorBoundary() {
+    return (
+        <html lang="ja">
+            <head>
+                <meta charSet="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <title>kicl</title>
+            </head>
+            <body className="min-h-screen min-w-screen">
+                <Nav/>
+                <div className="p-8 text-red-600">
+                    <h1 className="text-xl font-bold">エラーが発生しました</h1>
+                    <p>ページを表示中に問題が発生しました。</p>
+                </div>
+            </body>
+        </html>
+    );
+}


### PR DESCRIPTION
## 概要
前回の修正（`routes.tsx` で `root.tsx` を明示的にネスト）がCIでビルドエラーを引き起こしたため、正しい修正アプローチでPRを出し直しました。

## 修正内容
### 1. `routes.tsx` の構成維持
React Router v7 のフレームワークモードでは、`app/root.tsx` は自動的に全ルートの親となるため、`routes.tsx` での明示的な宣言は不要であり、エラーの原因となります。`develop` ブランチの構成を維持しました。

### 2. `root.tsx` への `ErrorBoundary` 追加
トップページ等でレンダリングエラーが発生した場合にナビゲーションバーが消えてしまう問題に対処するため、`root.tsx` に `ErrorBoundary` を追加しました。これにより、エラー発生時もナビゲーションバーと簡易エラー画面が表示されます。

```tsx
export function ErrorBoundary() {
    return (
        <html lang="ja">
            {/* ... head ... */}
            <body>
                <Nav/>
                <div>エラーが発生しました</div>
            </body>
        </html>
    );
}
```

## 関連
- 閉じるべきPR: #308 (`fix/kicl-web-nav-on-index`)