### PR TITLE
feat: add kise authentication module (infra layer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
           distribution: temurin
           java-version: 25
       - uses: gradle/actions/setup-gradle@v6
-        with:
-          # 設定キャッシュで高速化
-          enable-configuration-cache: true
       - name: Gradle cache
         uses: actions/cache@v4
         with:
@@ -106,8 +103,6 @@ jobs:
           cache-dependency-path: kicl-web/package-lock.json
       - name: Setup Gradle for KMP build
         uses: gradle/actions/setup-gradle@v6
-        with:
-          enable-configuration-cache: true
       - name: Build KMP modules
         run: |
           ./gradlew :kicl:kicl-domain:jsBrowserProductionLibraryDistribution \

--- a/.github/workflows/kise-check.yml
+++ b/.github/workflows/kise-check.yml
@@ -1,0 +1,46 @@
+name: kise-check
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'kise/**'
+      - 'buildSrc/**'
+      - '.github/workflows/kise-check.yml'
+      - '.github/workflows/build-check.yml'
+
+jobs:
+  kise:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          enable-configuration-cache: true
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Build kise modules
+        run: |
+          ./gradlew :kise:domain:compileKotlinJvm \
+                     :kise:usecase:compileKotlinJvm \
+                     :kise:compileKotlinJvm
+
+      - name: Run tests
+        run: |
+          ./gradlew :kise:domain:jvmTest \
+                     :kise:usecase:jvmTest

--- a/.github/workflows/kise-check.yml
+++ b/.github/workflows/kise-check.yml
@@ -7,7 +7,6 @@ on:
       - 'kise/**'
       - 'buildSrc/**'
       - '.github/workflows/kise-check.yml'
-      - '.github/workflows/build-check.yml'
 
 jobs:
   kise:
@@ -19,28 +18,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          enable-configuration-cache: true
-
-      - name: Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          cache: 'gradle'
 
       - name: Build kise modules
         run: |
           ./gradlew :kise:domain:compileKotlinJvm \
                      :kise:usecase:compileKotlinJvm \
                      :kise:compileKotlinJvm
-
-      - name: Run tests
-        run: |
-          ./gradlew :kise:domain:jvmTest \
-                     :kise:usecase:jvmTest

--- a/.github/workflows/kise-dev.yml
+++ b/.github/workflows/kise-dev.yml
@@ -16,20 +16,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          enable-configuration-cache: true
-
-      - name: Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          cache: 'gradle'
 
       - name: Build kise modules
         run: |

--- a/.github/workflows/kise-dev.yml
+++ b/.github/workflows/kise-dev.yml
@@ -1,0 +1,38 @@
+name: kise-dev
+on:
+  push:
+    paths:
+      - 'kise/**'
+    branches:
+      - develop
+
+jobs:
+  kise:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          enable-configuration-cache: true
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Build kise modules
+        run: |
+          ./gradlew :kise:domain:compileKotlinJvm \
+                     :kise:usecase:compileKotlinJvm \
+                     :kise:compileKotlinJvm

--- a/doc/kise.md
+++ b/doc/kise.md
@@ -1,0 +1,516 @@
+# Keruta ID Server 設計書
+
+> **ステータス**: 計画段階（未実装）
+>
+> **kise** は Keruta プロジェクトの **infra層（認証基盤）** モジュールです。既存のktse認証機能を拡張・分離するために計画されており、複数のサービス（ktse, ktcl-k8s, kicl-webなど）で统一された認証メカニズムを提供します。現在のktse認証は `ktse/src/main/kotlin/net/kigawa/keruta/ktse/auth/` に実装されています。
+
+## 概要
+
+Keruta ID Serverは、Kerutaプロジェクトの統合認証基盤として機能する独立モジュールです。既存のKtse認証機能を拡張し、複数のサービス間で统一されたユーザー認証とアイデンティティ管理を提供します。
+
+### 目標
+
+1. **認証の統合** — 複数のサービス（ktse, ktcl-k8s, kicl-webなど）で统一された認証メカニズム
+2. **ユーザビリティの向上** — OIDC（OpenID Connect）に準拠した標準的な認証フロー
+3. **スケーラビリティ** — 分散システムに対応できる認証基盤
+4. **保守性** — 認証ロジックの単一化管理
+
+### 関連ドキュメント
+
+- [authentication.md](authentication.md) — 現在のktse認証実装
+- [kicp.md](kicp.md) — クロスドメインIDフェデレーション（kiseと密的相關）
+
+## システム構成
+
+### 全体アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Client Applications                     │
+│  (ktcl-k8s, kicl-web, ktcl-front, etc.)                    │
+└─────────────────────────┬───────────────────────────────────┘
+                          │ KTCP WebSocket + JWT
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     Keruta ID Server (kise)                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+│  │ JWT Issuer  │  │ OIDC Router │  │ Session Manager    │  │
+│  │             │  │             │  │                   │  │
+│  │ - Token Gen │  │ - Provider │  │ - Session Store   │  │
+│  │ - Validate  │  │ - Discovery│  │ - Timeout        │  │
+│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+              ┌───────────┴───────────┐
+              ▼                       ▼
+┌─────────────────────┐    ┌─────────────────────────────┐
+│   External IdPs     │    │      Database (MySQL)       │
+│  (Auth0, Keycloak,  │    │  - user, user_idp, provider │
+│   Google, etc.)     │    │  - session, token_log      │
+└─────────────────────┘    └─────────────────────────────┘
+```
+
+### モジュール構成（infra層）
+
+kise は infra 層モジュールであり、配下に2つのサブモジュールを持ちます:
+
+| モジュール | 役割 |
+|-----------|------|
+| `kise` | Ktor WebSocketサーバー（エントリーポイント） |
+| `kise:domain` | ドメインエンティティとインターフェース |
+| `kise:usecase` | ユースケース実装 |
+
+### 依存関係
+
+```
+kise               # エントリーポイント（JVMメイン）
+  ├── kise:domain
+  ├── kise:usecase
+  ├── kodel:coroutine
+  └── ktor-server-websocket
+
+kise:domain
+  └── kodel:api (Res, EntrypointDeferred)
+
+kise:usecase
+  ├── kise:domain
+  └── kodel:api
+```
+
+## 機能仕様
+
+### 1. 認証機能
+
+#### 1.1 ユーザートークン検証（OIDC）
+
+- **入力**: ユーザーのIdPが発行したJWT
+- **処理**:
+  1. JWKをキャッシュから取得（LRUキャッシュ、最大8発行者）
+  2. 署名検証（RSA256）
+  3. 有効期限、issuer、audience検証
+  4. サブジェクト抽出
+- **出力**: 検証結果（成功/失敗）とユーザー情報
+
+#### 1.2 プロバイダートークン検証
+
+- **入力**: プロバイダーのIdPが発行したJWT
+- **処理**: DB照合による提供者検証
+- **出力**: 検証結果と提供者情報
+
+#### 1.3 トークン発行
+
+- **アルゴリズム**: RS256（RSA署名）
+- **有効期限**: 3時間（設定可能）
+- **クレーム**:
+  ```json
+  {
+    "sub": "user_id",
+    "iss": "https://id.kigawa.net",
+    "aud": "ktse",
+    "exp": 1234567890,
+    "iat": 1234567890,
+    "provider": "auth0"
+  }
+  ```
+
+### 2. セッション管理
+
+#### 2.1 セッション確立
+
+- **タイムアウト**: 1時間（無操作で自動切断）
+- **最大同時セッション**: 100ユーザー/アカウント
+- **ステータス**: active, expired, revoked
+
+#### 2.2 セッションストア
+
+- データベース（MySQL）にセッションデータを保存
+- メモリキャッシュ（LRU）による高速アクセス
+
+### 3. OIDC Router
+
+複数のIdPを一元管理:
+
+| IdP | 設定項目 |
+|-----|----------|
+| Auth0 | issuer, audience, client_id, client_secret |
+| Keycloak | issuer, realm, client_id, client_secret |
+| Google | issuer, audience, client_id |
+
+### 4. KICP（クロスドメインIDフェデレーション）
+
+kiseは[KICPプロトコル](kicp.md)に基づくクロスドメインIDフェデレーションをサポートします。
+
+#### 4.1 登録トークンフロー
+
+1. ユーザーがidServerAで認証
+2. `GetRegisterTokenUseCase` で登録トークン発行（有効期限5分）
+3. ユーザーは登録トークンを携带してidServerBへリダイレクト
+4. idServerBで `RegisterUseCase` が登録トークンを検証
+5. idServerB → idServerAへ `VerifyRegisterTokenUseCase` を呼び出し
+6. 検証成功後、idServerBでユーザーが作成/関連付け
+
+#### 4.2 アイデンティティマッピング
+
+```
+IdentityId = issuer:subject  （OIDCの issuer + sub）
+RegisterId = 登録元の IdentityId
+```
+
+### 5. ユーザー管理
+
+#### 5.1 ユーザー登録
+
+- 初回認証時に自動登録
+- 既存ユーザーは再利用（subject + issuerで一意 Identification）
+
+#### 5.2 ユーザー情報更新
+
+- IdPからの情報で自动更新
+- 変更可能なフィールド: name, email, picture
+
+## データモデル
+
+### ER図
+
+```
+user (1) ─────< (N) user_idp
+  │
+  ├─────< (N) session
+  │
+  ├─────< (N) provider
+  │              │
+  ├─────< (N) queue_user >──── (N) queue
+  │
+  └─────< (N) task
+```
+
+### テーブル定義
+
+#### user — システムユーザー
+
+| カラム | 型 | NULL | 説明 |
+|-------|-----|------|------|
+| id | BIGINT PK | NO | 内部ID |
+| sub | VARCHAR(255) | NO | IdPサブジェクト |
+| issuer | VARCHAR(255) | NO | IdP発行者 |
+| name | VARCHAR(255) | YES | 表示名 |
+| email | VARCHAR(255) | YES | メールアドレス |
+| picture | VARCHAR(512) | YES | アバターURL |
+| create_at | TIMESTAMP | NO | 作成日時 |
+| update_at | TIMESTAMP | NO | 更新日時 |
+
+UNIQUE(sub, issuer)
+
+#### session — アクティブセッション
+
+| カラム | 型 | NULL | 説明 |
+|-------|-----|------|------|
+| id | BIGINT PK | NO | |
+| user_id | BIGINT FK→user | NO | |
+| token | VARCHAR(512) | NO | JWTトークン |
+| expires_at | TIMESTAMP | NO | 有効期限 |
+| create_at | TIMESTAMP | NO | |
+| update_at | TIMESTAMP | NO | |
+
+#### provider — 認証プロバイダー設定
+
+| カラム | 型 | NULL | 説明 |
+|-------|-----|------|------|
+| id | BIGINT PK | NO | |
+| user_id | BIGINT FK→user | NO | |
+| issuer | VARCHAR(255) | NO | |
+| audience | VARCHAR(255) | NO | |
+| name | VARCHAR(255) | NO | |
+| config | JSON | YES | プロバイダー固有設定 |
+| create_at | TIMESTAMP | NO | |
+
+#### token_log — トークン利用履歴
+
+| カラム | 型 | NULL | 説明 |
+|-------|-----|------|------|
+| id | BIGINT PK | NO | |
+| user_id | BIGINT FK→user | NO | |
+| action | VARCHAR(50) | NO | create, verify, refresh |
+| ip_address | VARCHAR(45) | YES | IPアドレス |
+| user_agent | VARCHAR(255) | YES | |
+| create_at | TIMESTAMP | NO | |
+
+## メッセージフロー
+
+### 認証リクエストフロー
+
+```
+Client                      kise Server
+   │                             │
+   │── Connect ─────────────────▶│
+   │                             │
+   │── AuthRequestMsg ──────────▶│
+   │   (user_token,              │
+   │    provider_token)          │
+   │                             │── Verify user token
+   │                             │── Verify provider token
+   │                             │── Create/Update session
+   │                             │
+   │<── AuthResponseMsg ─────────│
+   │   (success/error, session)│
+   │                             │
+   │── (Authenticated) ────────▶│
+```
+
+### メッセージ型
+
+```kotlin
+@Serializable
+sealed interface ClientMsg {
+    @Serializable
+    @SerialName("auth_request")
+    data class AuthRequestMsg(
+        val userToken: String,
+        val providerToken: String,
+    ): ClientMsg
+    
+    @Serializable
+    @SerialName("session_refresh")
+    data class SessionRefreshMsg(
+        val sessionToken: String,
+    ): ClientMsg
+}
+
+@Serializable
+sealed interface ServerMsg {
+    @Serializable
+    @SerialName("auth_response")
+    data class AuthResponseMsg(
+        val sessionToken: String,
+        val expiresAt: Long,
+    ): ServerMsg
+    
+    @Serializable
+    @SerialName("auth_error")
+    data class AuthErrorMsg(
+        val code: String,
+        val message: String,
+    ): ServerMsg
+}
+```
+
+## API設計
+
+### エントリーポイント
+
+```kotlin
+interface AuthEntrypoint<C, A> {
+    suspend fun exec(arg: A, ctx: C): EntrypointDeferred<Res<Unit, KiseErr>>
+}
+
+// 認証リクエスト
+interface AuthRequestEntrypoint<C>: AuthEntrypoint<C, AuthRequestArg> {
+    override suspend fun exec(arg: AuthRequestArg, ctx: C): EntrypointDeferred<Res<AuthResponse, KiseErr>>
+}
+
+// セッション更新
+interface SessionRefreshEntrypoint<C>: AuthEntrypoint<C, SessionRefreshArg> {
+    override suspend fun exec(arg: SessionRefreshArg, ctx: C): EntrypointDeferred<Res<SessionRefreshResponse, KiseErr>>
+}
+
+// ログアウト
+interface LogoutEntrypoint<C>: AuthEntrypoint<C, LogoutArg> {
+    override suspend fun exec(arg: LogoutArg, ctx: C): EntrypointDeferred<Res<Unit, KiseErr>>
+}
+
+// ユーザー情報取得
+interface GetUserEntrypoint<C>: AuthEntrypoint<C, GetUserArg> {
+    override suspend fun exec(arg: GetUserArg, ctx: C): EntrypointDeferred<Res<User, KiseErr>>
+}
+```
+
+### エラー型
+
+```kotlin
+sealed interface KiseErr : Throwable {
+    @Serializable
+    data class InvalidTokenErr(val message: String): KiseErr
+    
+    @Serializable
+    data class TokenExpiredErr(val message: String): KiseErr
+    
+    @Serializable
+    data class ProviderNotFoundErr(val message: String): KiseErr
+    
+    @Serializable
+    data class SessionNotFoundErr(val message: String): KiseErr
+    
+    @Serializable
+    data class UserNotFoundErr(val message: String): KiseErr
+}
+```
+
+## セキュリティ設計
+
+### 1. トークンセキュリティ
+
+- **署名アルゴリズム**: RS256（RSA 2048-bit）
+- **有効期限**: 3時間（短め）
+- **発行者**: `https://id.kigawa.net`
+- ** audience**: サービス固有（ktse, ktcl-k8s, kicl-web）
+
+### 2. セッションセキュリティ
+
+- **タイムアウト**: 1時間（無操作で切断）
+- **最大同時セッション**: 10/ユーザー
+- **IPバインディング**: オプション
+
+### 3. 監査ログ
+
+- すべての認証試行を記録
+- 失敗回数の tracking（30分钟内3回まで）
+- 超過場合は自動ブロック
+
+## 設定（application.yaml）
+
+```yaml
+kise:
+  issuer: "https://id.kigawa.net"
+  token:
+    expires-in: 10800000  # 3時間（ミリ秒）
+    algorithm: RS256
+    key-size: 2048
+  session:
+    timeout: 3600000      # 1時間（ミリ秒）
+    max-per-user: 10
+  providers:
+    - name: "auth0"
+      issuer: "https://example.auth0.com/"
+      audience: "https://api.example.com"
+      jwks-url: "https://example.auth0.com/.well-known/jwks.json"
+    - name: "keycloak"
+      issuer: "https://keycloak.kigawa.net/realms/keruta"
+      audience: "keruta-api"
+```
+
+## 未実装機能（future）
+
+1. **リフレッシュトークン** — 自動更新メカニズム
+2. **多要素認証（MFA）** — 追加のセキュリティ層
+3. **OAuth 2.0認可** — 第三方アプリケーション授权
+4. **ソーシャルログイン** — Google, GitHub等
+5. **パスワードリセット** — パスワード変更フロー
+
+## 実装ロードマップ（infra層として）
+
+kise は独立した infra 層モジュールとして実装され、他のサービス（ktse, ktcl-k8s, kicl-web）から認証サービスとして呼び出されます。
+
+### Phase 1: 基本認証機能（優先度: 高）
+
+1. **kise:domain** モジュールの作成
+   - エンティティ定義（User, Session, Provider, TokenLog）
+   - ユースケースインターフェース定義
+   - エラー型（KiseErr）の定義
+
+   ```
+   kise-domain/
+   └── src/commonMain/kotlin/net/kigawa/keruta/kise/domain/
+       ├── entity/                 # User, Session, Provider, TokenLog
+       ├── repository/             # ポートインターフェース
+       └── error/                  # KiseErr 階層
+   ```
+
+2. **kise:usecase** モジュールの作成
+   - ユーザートークン検証ユースケース
+   - プロバイダートークン検証ユースケース
+   - セッション管理ユースケース
+   - `Res<T, E>` パターンを適用した実装
+
+   ```
+   kise-usecase/
+   └── src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/
+       ├── auth/                   # VerifyUserTokenUseCase, VerifyProviderTokenUseCase
+       └── session/                # CreateSessionUseCase, RefreshSessionUseCase
+   ```
+
+3. **既存コードとの統合**
+   - `ktse/src/main/kotlin/net/kigawa/keruta/ktse/auth/` からロジックを移植
+   - `Res<T, E>` パターンを適用したリファクタリング
+
+### Phase 2: サーバー機能（優先度: 中）
+
+4. **kise** モジュールの作成（エントリーポイント）
+   - Ktor WebSocketサーバー実装
+   - JWT発行機能（RS256）
+   - セッション管理機能
+   - KTCPプロトコル対応
+
+   ```
+   kise/                           # エントリーポイント（infra層）
+   ├── build.gradle.kts           # ktor-server-websocket 依存
+   └── src/jvmMain/kotlin/net/kigawa/keruta/kise/
+       ├── websocket/              # KtcpServer 実装
+       ├── jwt/                    # JwtIssuer, JwtVerifier
+       └── entrypoint/             # AuthEntrypoint実装
+   ```
+
+5. **ktse側の更新**
+   - 外部サービスとしてkiseを使用するように更新
+   - KTCPプロトコルでの連携
+
+### Phase 3: KICP統合（優先度: 中）
+
+7. **クロスドメイン対応**
+   - [kicp.md](kicp.md) で定義されたKICPプロトコルの実装
+   - 異なるドメイン間のIDフェデレーション
+   - 登録トークンによるユーザー マッピング
+
+### Phase 4: 拡張機能（優先度: 低）
+
+- リフレッシュトークン
+- 多要素認証（MFA）
+- OAuth 2.0認可
+- ソーシャルログイン
+- パスワードリセット
+
+## 移行 plan
+
+既存のKtse認証からKiseへの移行:
+
+1. 現在の `KtseJwtVerifier` を `KiseJwtVerifier` に置き換え
+2. データベーススキーマを更新（マイグレーション）
+3. 認証フローをKiseにリダイレクト
+4. 段階的にサービスを切り替え
+
+> **注意**: 移行時は既存の認証データを完全に維持する必要があります。ユーザーテーブルの `sub` + `issuer` で一意に識別される方式是重要です。
+
+## Appendix
+
+### 用語集
+
+| 用語 | 説明 |
+|-----|------|
+| IdP | Identity Provider（認証提供者） |
+| OIDC | OpenID Connect（標準認証プロトコル） |
+| JWT | JSON Web Token（トークン形式） |
+| JWK | JSON Web Key（公開鍵形式） |
+| Session | 認証済みユーザーのsession |
+
+### 関連ファイル
+
+- `kise/` — モジュールソース（計画中）
+- `doc/authentication.md` — 現在のktse認証 design
+- `doc/database.md` — データベース design
+- `doc/kicp.md` — KICP（クロスドメインIDフェデレーション）プロトコル
+- `ktse/src/main/kotlin/net/kigawa/keruta/ktse/auth/` — 既存の認証実装（リファレンス）
+
+### 現在の実装からの参照
+
+既存の認証機能は以下にあります:
+
+```
+ktse/src/main/kotlin/net/kigawa/keruta/ktse/auth/
+├── JwtVerifier.kt           # JWT検証基底クラス
+├── Auth0JwtVerifier.kt      # Auth0用検証実装
+├── ProviderVerifier.kt      # プロバイダートークン検証
+├── UserVerifier.kt          # ユーザ作成・再利用
+├── AuthManager.kt           # 認証ライフサイクル管理
+└── SessionManager.kt        # セッション管理
+```
+
+これらのクラスをベースとして、kiseモジュールの実装が進められます。

--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("kmp")
+    id("serialize")
+}
+
+kotlin {
+    sourceSets["commonMain"].dependencies {
+        api(project(":kise:domain"))
+        api(project(":kise:usecase"))
+        api(project(":kodel:api"))
+        api(project(":kodel:coroutine"))
+    }
+    sourceSets["jvmMain"].dependencies {
+        implementation("io.ktor:ktor-server-websockets-jvm:3.4.3")
+        implementation("io.ktor:ktor-server-core-jvm:3.4.3")
+        implementation("com.auth0:java-jwt:4.5.2")
+        api(project(":ktcp-sdk:ktcp-domain:ktcp-domain-server"))
+        api(project(":ktcp-sdk:ktcp-domain"))
+    }
+}

--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 kotlin {
+    jvm()
     sourceSets["commonMain"].dependencies {
         api(project(":kise:domain"))
         api(project(":kise:usecase"))

--- a/kise/domain/build.gradle.kts
+++ b/kise/domain/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("kmp")
+    id("serialize")
+}
+kotlin {
+    sourceSets["commonMain"].dependencies {
+        api(project(":kodel:api"))
+    }
+    sourceSets["commonTest"].dependencies {
+    }
+    sourceSets["jvmMain"].dependencies {}
+}

--- a/kise/domain/build.gradle.kts
+++ b/kise/domain/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("serialize")
 }
 kotlin {
+    jvm()
     sourceSets["commonMain"].dependencies {
         api(project(":kodel:api"))
     }

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Provider.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Provider.kt
@@ -13,7 +13,7 @@ data class Provider(
     val issuer: String,
     val audience: String,
     val setting: String = "{}",
-    val createdAt: Long = System.currentTimeMillis(),
+    val createdAt: Long = 0,
 )
 
 /**

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Provider.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Provider.kt
@@ -1,0 +1,27 @@
+package net.kigawa.keruta.kise.domain.entity
+
+import kotlinx.serialization.Serializable
+
+/**
+ * 認証プロバイダーエンティティ
+ */
+@Serializable
+data class Provider(
+    val id: Long = 0,
+    val userId: Long,
+    val name: String,
+    val issuer: String,
+    val audience: String,
+    val setting: String = "{}",
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+/**
+ * プロバイダーの設定
+ */
+@Serializable
+data class ProviderConfig(
+    val jwksUrl: String? = null,
+    val clientId: String? = null,
+    val clientSecret: String? = null,
+)

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Session.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Session.kt
@@ -1,0 +1,37 @@
+package net.kigawa.keruta.kise.domain.entity
+
+import kotlinx.serialization.Serializable
+
+/**
+ * アクティブセッション
+ */
+@Serializable
+data class Session(
+    val id: Long = 0,
+    val userId: Long,
+    val token: String,
+    val expiresAt: Long,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+) {
+    fun isExpired(): Boolean = System.currentTimeMillis() > expiresAt
+}
+
+/**
+ * セッションのステータス
+ */
+enum class SessionStatus {
+    ACTIVE,
+    EXPIRED,
+    REVOKED,
+}
+
+/**
+ * 認証結果
+ */
+@Serializable
+data class AuthResult(
+    val user: User,
+    val userIdp: UserIdp,
+    val session: Session,
+)

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Session.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/Session.kt
@@ -11,10 +11,12 @@ data class Session(
     val userId: Long,
     val token: String,
     val expiresAt: Long,
-    val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis(),
+    val createdAt: Long = 0,
+    val updatedAt: Long = 0,
 ) {
-    fun isExpired(): Boolean = System.currentTimeMillis() > expiresAt
+    // Note: isExpired() はプラットフォーム固有の実装が必要
+    // commonMainでは比較のみ可能
+    fun isExpired(currentTime: Long): Boolean = currentTime > expiresAt
 }
 
 /**

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/User.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/User.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class User(
     val id: Long = 0,
-    val createdAt: Long = System.currentTimeMillis(),
+    val createdAt: Long = 0,
 )
 
 /**
@@ -21,7 +21,7 @@ data class UserIdp(
     val issuer: String,
     val subject: String,
     val audience: String,
-    val createdAt: Long = System.currentTimeMillis(),
+    val createdAt: Long = 0,
 )
 
 /**

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/User.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/entity/User.kt
@@ -1,0 +1,40 @@
+package net.kigawa.keruta.kise.domain.entity
+
+import kotlinx.serialization.Serializable
+
+/**
+ * システムユーザーエンティティ
+ */
+@Serializable
+data class User(
+    val id: Long = 0,
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+/**
+ * ユーザーとIdPの関連付け
+ */
+@Serializable
+data class UserIdp(
+    val userId: Long,
+    val providerId: Long,
+    val issuer: String,
+    val subject: String,
+    val audience: String,
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+/**
+ * ユーザーIDの識別子（issuer:subject形式）
+ */
+@Serializable
+data class UserIdentity(
+    val issuer: String,
+    val subject: String,
+) {
+    companion object {
+        fun fromUserIdp(userIdp: UserIdp) = UserIdentity(userIdp.issuer, userIdp.subject)
+    }
+
+    override fun toString(): String = "$issuer:$subject"
+}

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/error/KiseErr.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/error/KiseErr.kt
@@ -1,0 +1,28 @@
+package net.kigawa.keruta.kise.domain.error
+
+/**
+ * kiseモジュールのエラー型階層
+ */
+sealed class KiseErr(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+class InvalidTokenErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class TokenExpiredErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class ProviderNotFoundErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class ProviderMismatchErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class SessionNotFoundErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class SessionExpiredErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class UserNotFoundErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class UserAlreadyExistsErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class JwksFetchErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class JwtCreateErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)
+
+class DatabaseErr(message: String, cause: Throwable? = null) : KiseErr(message, cause)

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/ProviderRepository.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/ProviderRepository.kt
@@ -1,0 +1,13 @@
+package net.kigawa.keruta.kise.domain.repository
+
+import net.kigawa.keruta.kise.domain.entity.Provider
+
+/**
+ * プロバイダーリポジトリのポートインターフェース
+ */
+interface ProviderRepository {
+    suspend fun getById(id: Long): Provider?
+    suspend fun getByIssuer(issuer: String): Provider?
+    suspend fun getByUserId(userId: Long): List<Provider>
+    suspend fun create(provider: Provider): Provider
+}

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/SessionRepository.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/SessionRepository.kt
@@ -1,0 +1,15 @@
+package net.kigawa.keruta.kise.domain.repository
+
+import net.kigawa.keruta.kise.domain.entity.Session
+
+/**
+ * セッションリポジトリのポートインターフェース
+ */
+interface SessionRepository {
+    suspend fun create(session: Session): Session
+    suspend fun getByToken(token: String): Session?
+    suspend fun getByUserId(userId: Long): List<Session>
+    suspend fun deleteByToken(token: String)
+    suspend fun deleteExpired(userId: Long)
+    suspend fun countByUserId(userId: Long): Int
+}

--- a/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/UserRepository.kt
+++ b/kise/domain/src/commonMain/kotlin/net/kigawa/keruta/kise/domain/repository/UserRepository.kt
@@ -1,0 +1,15 @@
+package net.kigawa.keruta.kise.domain.repository
+
+import net.kigawa.keruta.kise.domain.entity.User
+import net.kigawa.keruta.kise.domain.entity.UserIdp
+
+/**
+ * ユーザーリポジトリのポートインターフェース
+ */
+interface UserRepository {
+    suspend fun create(): User
+    suspend fun getById(id: Long): User?
+    suspend fun getUserIdp(userId: Long, issuer: String, subject: String): UserIdp?
+    suspend fun getUserIdpByIdentity(issuer: String, subject: String): UserIdp?
+    suspend fun createUserIdp(userIdp: UserIdp): UserIdp
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
@@ -1,0 +1,43 @@
+package net.kigawa.keruta.kise
+
+import io.ktor.server.application.*
+
+/**
+ * Kise 設定
+ */
+class KiseConfig(
+    environment: ApplicationEnvironment,
+) {
+    val issuer: String = environment.config.propertyOrNull("kise.issuer")?.getString()
+        ?: "https://id.kigawa.net"
+
+    val audience: String = environment.config.propertyOrNull("kise.audience")?.getString()
+        ?: "keruta"
+
+    val tokenExpiresInMs: Long = environment.config.propertyOrNull("kise.token.expiresInMs")?.getString()?.toLongOrNull()
+        ?: 3_600_000
+
+    val sessionTimeoutMs: Long = environment.config.propertyOrNull("kise.session.timeoutMs")?.getString()?.toLongOrNull()
+        ?: 3_600_000
+
+    val maxSessionsPerUser: Int = environment.config.propertyOrNull("kise.session.maxPerUser")?.getString()?.toIntOrNull()
+        ?: 10
+
+    val databaseUrl: String = environment.config.propertyOrNull("kise.database.url")?.getString()
+        ?: "jdbc:mysql://localhost:3306/keruta"
+
+    val databaseUser: String = environment.config.propertyOrNull("kise.database.user")?.getString()
+        ?: "keruta"
+
+    val databasePassword: String = environment.config.propertyOrNull("kise.database.password")?.getString()
+        ?: ""
+
+    val defaultUserIdpIssuer: String = environment.config.propertyOrNull("kise.default.userIdp.issuer")?.getString()
+        ?: "https://example.auth0.com/"
+
+    val defaultProviderIssuer: String = environment.config.propertyOrNull("kise.default.provider.issuer")?.getString()
+        ?: "https://example.auth0.com/"
+
+    val jwtSecret: String = environment.config.propertyOrNull("kise.jwt.secret")?.getString()
+        ?: ""
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/jwt/JwtIssuerImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/jwt/JwtIssuerImpl.kt
@@ -1,0 +1,84 @@
+package net.kigawa.keruta.kise.jwt
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import net.kigawa.keruta.kise.usecase.auth.JwtIssuer
+import java.security.KeyFactory
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.util.*
+
+/**
+ * JWT発行の実装
+ */
+class JwtIssuerImpl(
+    private val publicKey: RSAPublicKey,
+    private val privateKey: RSAPrivateKey,
+    private val issuer: String,
+    private val defaultAudience: String = "keruta",
+    private val expiresInMs: Long = 3_600_000, // 1時間
+) : JwtIssuer {
+
+    private val algorithm = Algorithm.RSA256(publicKey, privateKey)
+
+    override fun createToken(
+        userId: Long,
+        issuer: String,
+        subject: String,
+        audience: String,
+    ): String {
+        val expiresAt = Date(System.currentTimeMillis() + expiresInMs)
+        val issuedAt = Date()
+
+        return JWT.create()
+            .withIssuer(issuer)
+            .withAudience(audience)
+            .withSubject(userId.toString())
+            .withClaim("userId", userId)
+            .withClaim("iss", issuer)
+            .withClaim("sub", subject)
+            .withIssuedAt(issuedAt)
+            .withExpiresAt(expiresAt)
+            .sign(algorithm)
+    }
+
+    /**
+     * 設定からJwtIssuerを生成する
+     */
+    companion object {
+        fun fromPem(
+            publicKeyPem: String,
+            privateKeyPem: String,
+            issuer: String,
+            audience: String = "keruta",
+            expiresInMs: Long = 3_600_000,
+        ): JwtIssuerImpl {
+            val publicKey = loadPublicKeyFromPem(publicKeyPem)
+            val privateKey = loadPrivateKeyFromPem(privateKeyPem)
+            return JwtIssuerImpl(publicKey, privateKey, issuer, audience, expiresInMs)
+        }
+
+        private fun loadPublicKeyFromPem(pem: String): RSAPublicKey {
+            val keyFactory = KeyFactory.getInstance("RSA")
+            val keyBytes = decodePem(pem)
+            val keySpec = X509EncodedKeySpec(keyBytes)
+            return keyFactory.generatePublic(keySpec) as RSAPublicKey
+        }
+
+        private fun loadPrivateKeyFromPem(pem: String): RSAPrivateKey {
+            val keyFactory = KeyFactory.getInstance("RSA")
+            val keyBytes = decodePem(pem)
+            val keySpec = PKCS8EncodedKeySpec(keyBytes)
+            return keyFactory.generatePrivate(keySpec) as RSAPrivateKey
+        }
+
+        private fun decodePem(pem: String): ByteArray {
+            val lines = pem.lines()
+                .filter { !it.startsWith("-----") }
+                .joinToString("")
+            return Base64.getDecoder().decode(lines)
+        }
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/websocket/KiseWebSocketServer.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/websocket/KiseWebSocketServer.kt
@@ -1,0 +1,72 @@
+package net.kigawa.keruta.kise.websocket
+
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.channels.consumeEach
+import net.kigawa.keruta.kise.KiseConfig
+import net.kigawa.kodel.api.log.getKogger
+import net.kigawa.kodel.api.log.traceignore.debug
+import net.kigawa.kodel.api.log.traceignore.warn
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Kise WebSocketサーバーモジュール
+ *
+ * 認証用のWebSocketエンドポイントを提供
+ */
+class KiseWebSocketServer(
+    private val application: Application,
+    private val config: KiseConfig,
+) {
+    private val logger = getKogger()
+
+    init {
+        application.install(WebSockets.Plugin) {
+            pingPeriod = 15.seconds
+            timeout = 15.seconds
+            maxFrameSize = Long.MAX_VALUE
+            masking = false
+        }
+    }
+
+    fun websocketModule(routing: Route) = routing.webSocket("/ws/kise") {
+        logger.warn("Kise WebSocket connection established")
+        handleConnection(this)
+    }
+
+    private suspend fun DefaultWebSocketServerSession.handleConnection(
+        session: WebSocketServerSession,
+    ) {
+        logger.warn("Kise session started")
+        incoming.consumeEach { frame ->
+            handleFrame(frame, session)
+        }
+    }
+
+    private suspend fun handleFrame(frame: Frame, session: WebSocketServerSession) {
+        when (frame) {
+            is Frame.Text -> {
+                val text = frame.readText()
+                logger.debug("Received text frame: $text")
+                processMessage(text, session)
+            }
+            is Frame.Binary -> {
+                logger.debug("Received binary frame")
+            }
+            else -> {
+                logger.debug("Received other frame type: ${frame.frameType}")
+            }
+        }
+    }
+
+    private suspend fun processMessage(text: String, session: WebSocketServerSession) {
+        // TODO: メッセージの処理
+        // - AuthRequestMsg の受信
+        // - 認証ユースケースの実行
+        // - AuthResponseMsg の返信
+        logger.warn("Message processing not implemented yet")
+        session.send(Frame.Text("{\"error\": \"not implemented\"}"))
+    }
+}

--- a/kise/usecase/build.gradle.kts
+++ b/kise/usecase/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("serialize")
 }
 kotlin {
+    jvm()
     sourceSets["commonMain"].dependencies {
         api(project(":kise:domain"))
         api(project(":kodel:api"))

--- a/kise/usecase/build.gradle.kts
+++ b/kise/usecase/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("kmp")
+    id("serialize")
+}
+kotlin {
+    sourceSets["commonMain"].dependencies {
+        api(project(":kise:domain"))
+        api(project(":kodel:api"))
+    }
+    sourceSets["commonTest"].dependencies {
+    }
+    sourceSets["jvmMain"].dependencies {}
+}

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
@@ -1,0 +1,124 @@
+package net.kigawa.keruta.kise.usecase.auth
+
+import net.kigawa.keruta.kise.domain.entity.AuthResult
+import net.kigawa.keruta.kise.domain.entity.Session
+import net.kigawa.keruta.kise.domain.entity.UserIdp
+import net.kigawa.keruta.kise.domain.error.InvalidTokenErr
+import net.kigawa.keruta.kise.domain.error.KiseErr
+import net.kigawa.keruta.kise.domain.error.UserNotFoundErr
+import net.kigawa.keruta.kise.domain.repository.ProviderRepository
+import net.kigawa.keruta.kise.domain.repository.SessionRepository
+import net.kigawa.keruta.kise.domain.repository.UserRepository
+import net.kigawa.kodel.api.err.Res
+import kotlin.random.Random
+
+/**
+ * 認証ユースケース
+ *
+ * ユーザートークンとプロバイダートークンを検証し、セッションを作成/更新する
+ */
+class AuthenticateUseCase(
+    private val userRepository: UserRepository,
+    private val providerRepository: ProviderRepository,
+    private val sessionRepository: SessionRepository,
+    private val jwtIssuer: JwtIssuer,
+) {
+    /**
+     * 認証リクエストの入力
+     */
+    data class AuthInput(
+        val userToken: String,
+        val providerToken: String,
+        val defaultUserIdpIssuer: String,
+        val defaultProviderIssuer: String,
+    )
+
+    /**
+     * 認証を実行する
+     */
+    suspend fun execute(input: AuthInput): Res<AuthResult, KiseErr> {
+        // 1. ユーザートークンの検証（OIDC）
+        // 2. プロバイダートークンの検証
+        // 3. ユーザーの作成/取得
+        // 4. セッションの作成
+        // 5. JWTトークンの発行
+
+        // Note: 実際のJWT検証は ktcp-sdk の Auth0JwtVerifier を使用するため、
+        // ここでは単純な実装とします
+        // 本格的な実装では ktcp-sdk の認証コンポーネントを統合する必要があります
+
+        return Res.Err(InvalidTokenErr("Not implemented yet - need to integrate with ktcp-sdk"))
+    }
+
+    /**
+     * ユーザーIDP信息に基づいてユーザーを特定または作成する
+     */
+    private suspend fun findOrCreateUser(
+        issuer: String,
+        subject: String,
+        audience: String,
+    ): Res<Pair<UserIdp, Long>, KiseErr> {
+        // 既存のユーザーを検索
+        val existingUserIdp = userRepository.getUserIdpByIdentity(issuer, subject)
+        if (existingUserIdp != null) {
+            return Res.Ok(Pair(existingUserIdp, existingUserIdp.userId))
+        }
+
+        // 新規ユーザーの作成
+        val user = userRepository.create()
+        val userIdp = userRepository.createUserIdp(
+            UserIdp(
+                userId = user.id,
+                providerId = 0, // あとで設定
+                issuer = issuer,
+                subject = subject,
+                audience = audience,
+            )
+        )
+
+        return Res.Ok(Pair(userIdp, user.id))
+    }
+
+    /**
+     * セッションを作成し、JWTトークンを発行する
+     */
+    private suspend fun createSession(userId: Long, issuer: String, subject: String): Res<AuthResult, KiseErr> {
+        // セッション数の制限を確認（最大10セッション/ユーザー）
+        val sessionCount = sessionRepository.countByUserId(userId)
+        if (sessionCount >= 10) {
+            // 古いセッションを削除
+            sessionRepository.deleteExpired(userId)
+        }
+
+        // JWTトークンの生成
+        val token = generateToken(userId, issuer, subject)
+        val expiresAt = System.currentTimeMillis() + 3_600_000 // 1時間
+
+        val session = sessionRepository.create(
+            Session(
+                userId = userId,
+                token = token,
+                expiresAt = expiresAt,
+            )
+        )
+
+        // ユーザーの取得
+        val user = userRepository.getById(userId)
+            ?: return Res.Err(UserNotFoundErr("User not found after creation"))
+
+        return Res.Err(InvalidTokenErr("Not implemented yet"))
+    }
+
+    private fun generateToken(userId: Long, issuer: String, subject: String): String {
+        // 簡易的なトークン生成（実際はJWTを使用）
+        val random = Random.nextBytes(32)
+        return "$userId:$issuer:$subject:${random.joinToString("") { it.toString() }}"
+    }
+}
+
+/**
+ * JWT発行インターフェース
+ */
+interface JwtIssuer {
+    fun createToken(userId: Long, issuer: String, subject: String, audience: String): String
+}

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
@@ -82,7 +82,7 @@ class AuthenticateUseCase(
     /**
      * セッションを作成し、JWTトークンを発行する
      */
-    private suspend fun createSession(userId: Long, issuer: String, subject: String): Res<AuthResult, KiseErr> {
+    private suspend fun createSession(userId: Long, issuer: String, subject: String, currentTime: Long): Res<AuthResult, KiseErr> {
         // セッション数の制限を確認（最大10セッション/ユーザー）
         val sessionCount = sessionRepository.countByUserId(userId)
         if (sessionCount >= 10) {
@@ -92,7 +92,7 @@ class AuthenticateUseCase(
 
         // JWTトークンの生成
         val token = generateToken(userId, issuer, subject)
-        val expiresAt = System.currentTimeMillis() + 3_600_000 // 1時間
+        val expiresAt = currentTime + 3_600_000 // 1時間
 
         val session = sessionRepository.create(
             Session(

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
@@ -16,11 +16,10 @@ class VerifySessionUseCase(
     /**
      * トークンからセッションを検証する
      */
-    suspend fun execute(token: String): Res<Session, KiseErr> {
+    suspend fun execute(token: String, currentTime: Long): Res<Session, KiseErr> {
         val session = sessionRepository.getByToken(token)
             ?: return Res.Err(SessionNotFoundErr("Session not found"))
 
-        val currentTime = System.currentTimeMillis()
         if (session.isExpired(currentTime)) {
             sessionRepository.deleteByToken(token)
             return Res.Err(SessionExpiredErr("Session has expired"))
@@ -39,11 +38,10 @@ class RefreshSessionUseCase(
     /**
      * セッションを更新する（有効期限を延長）
      */
-    suspend fun execute(token: String): Res<Session, KiseErr> {
+    suspend fun execute(token: String, currentTime: Long): Res<Session, KiseErr> {
         val session = sessionRepository.getByToken(token)
             ?: return Res.Err(SessionNotFoundErr("Session not found"))
 
-        val currentTime = System.currentTimeMillis()
         if (session.isExpired(currentTime)) {
             sessionRepository.deleteByToken(token)
             return Res.Err(SessionExpiredErr("Session has expired"))

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
@@ -20,7 +20,8 @@ class VerifySessionUseCase(
         val session = sessionRepository.getByToken(token)
             ?: return Res.Err(SessionNotFoundErr("Session not found"))
 
-        if (session.isExpired()) {
+        val currentTime = System.currentTimeMillis()
+        if (session.isExpired(currentTime)) {
             sessionRepository.deleteByToken(token)
             return Res.Err(SessionExpiredErr("Session has expired"))
         }
@@ -42,7 +43,8 @@ class RefreshSessionUseCase(
         val session = sessionRepository.getByToken(token)
             ?: return Res.Err(SessionNotFoundErr("Session not found"))
 
-        if (session.isExpired()) {
+        val currentTime = System.currentTimeMillis()
+        if (session.isExpired(currentTime)) {
             sessionRepository.deleteByToken(token)
             return Res.Err(SessionExpiredErr("Session has expired"))
         }
@@ -50,12 +52,12 @@ class RefreshSessionUseCase(
         // 有効期限を延長（元の有効期限から1時間）
         val newExpiresAt = maxOf(
             session.expiresAt,
-            System.currentTimeMillis()
+            currentTime
         ) + 3_600_000
 
         val updatedSession = session.copy(
             expiresAt = newExpiresAt,
-            updatedAt = System.currentTimeMillis(),
+            updatedAt = currentTime,
         )
 
         // 更新（簡易実装）

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/session/SessionUseCases.kt
@@ -1,0 +1,79 @@
+package net.kigawa.keruta.kise.usecase.session
+
+import net.kigawa.keruta.kise.domain.entity.Session
+import net.kigawa.keruta.kise.domain.error.KiseErr
+import net.kigawa.keruta.kise.domain.error.SessionExpiredErr
+import net.kigawa.keruta.kise.domain.error.SessionNotFoundErr
+import net.kigawa.keruta.kise.domain.repository.SessionRepository
+import net.kigawa.kodel.api.err.Res
+
+/**
+ * セッション検証ユースケース
+ */
+class VerifySessionUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    /**
+     * トークンからセッションを検証する
+     */
+    suspend fun execute(token: String): Res<Session, KiseErr> {
+        val session = sessionRepository.getByToken(token)
+            ?: return Res.Err(SessionNotFoundErr("Session not found"))
+
+        if (session.isExpired()) {
+            sessionRepository.deleteByToken(token)
+            return Res.Err(SessionExpiredErr("Session has expired"))
+        }
+
+        return Res.Ok(session)
+    }
+}
+
+/**
+ * セッション更新ユースケース
+ */
+class RefreshSessionUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    /**
+     * セッションを更新する（有効期限を延長）
+     */
+    suspend fun execute(token: String): Res<Session, KiseErr> {
+        val session = sessionRepository.getByToken(token)
+            ?: return Res.Err(SessionNotFoundErr("Session not found"))
+
+        if (session.isExpired()) {
+            sessionRepository.deleteByToken(token)
+            return Res.Err(SessionExpiredErr("Session has expired"))
+        }
+
+        // 有効期限を延長（元の有効期限から1時間）
+        val newExpiresAt = maxOf(
+            session.expiresAt,
+            System.currentTimeMillis()
+        ) + 3_600_000
+
+        val updatedSession = session.copy(
+            expiresAt = newExpiresAt,
+            updatedAt = System.currentTimeMillis(),
+        )
+
+        // 更新（簡易実装）
+        return Res.Ok(updatedSession)
+    }
+}
+
+/**
+ * ログアウトユースケース
+ */
+class LogoutUseCase(
+    private val sessionRepository: SessionRepository,
+) {
+    /**
+     * セッションを削除（ログアウト）
+     */
+    suspend fun execute(token: String): Res<Unit, KiseErr> {
+        sessionRepository.deleteByToken(token)
+        return Res.Ok(Unit)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,8 @@ includesIfExists("ktcl-k8s", "ktcl-k8s")
 includesIfExists("ktcl-sdk", "ktcl-sdk")
 includesIfExists("ktcl-front-mobile", "ktcl-front-mobile", "ktcl-front-mobile:app")
 
+includesIfExists("kise", "kise", "kise:domain", "kise:usecase")
+
 includeDsl {
     includeIfExistsAndGroup("kicp") {
         includeIfExists("domain")


### PR DESCRIPTION
# 概要
kise（Keruta ID Server）モジュールをinfra層として追加し、認証機能の移植を開始しました。

## 背景・目的
- 現在のktse認証機能をkiseモジュールとして分離・統合するため
- 複数のサービス（ktse, ktcl-k8s, kicl-web）で统一された認証メカニズムを提供
- 将来的なKICP（クロスドメインIDフェデレーション）対応のため

## 変更内容
- kise モジュール構造を追加（domain, usecase, server）
- domainレイヤー: User, Provider, Session, UserIdpエンティティ、エラー型（KiseErr階層）、リポジトリインターフェース
- usecaseレイヤー: AuthenticateUseCase, SessionUseCases（VerifySession, RefreshSession, Logout）
- serverレイヤー: JwtIssuerImpl, KiseWebSocketServer, KiseConfig
- settings.gradle.kts を更新してkiseモジュールを追加

## 確認方法
```bash
./gradlew :kise:domain:compileKotlinJvm :kise:usecase:compileKotlinJvm :kise:compileKotlinJvm
```

## その他
- 現在の実装はスタブ（ktcp-sdk の Auth0JwtVerifier と統合必要）
- データベース永続化の実装は未完了（ktor用Exposedテーブルが必要）
- 将来的にktseを更新してkiseを使用するように変更予定