### PR TITLE
feat: add kise authentication module with persistence layer

### DIFF
--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -17,5 +17,12 @@ kotlin {
         implementation("com.auth0:java-jwt:4.5.2")
         api(project(":ktcp-sdk:ktcp-domain:ktcp-domain-server"))
         api(project(":ktcp-sdk:ktcp-domain"))
+        // Database
+        implementation("org.jetbrains.exposed:exposed-core:0.61.0")
+        implementation("org.jetbrains.exposed:exposed-dao:0.61.0")
+        implementation("org.jetbrains.exposed:exposed-jdbc:0.61.0")
+        implementation("org.jetbrains.exposed:exposed-kotlin-datetime:0.61.0")
+        implementation("com.mysql:mysql-connector-j:9.7.0")
+        implementation("com.zaxxer:HikariCP:7.0.2")
     }
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
@@ -38,6 +38,9 @@ class KiseConfig(
     val defaultProviderIssuer: String = environment.config.propertyOrNull("kise.default.provider.issuer")?.getString()
         ?: "https://example.auth0.com/"
 
-    val jwtSecret: String = environment.config.propertyOrNull("kise.jwt.secret")?.getString()
+    val jwtPublicKey: String = environment.config.propertyOrNull("kise.jwt.publicKey")?.getString()
+        ?: ""
+
+    val jwtPrivateKey: String = environment.config.propertyOrNull("kise.jwt.privateKey")?.getString()
         ?: ""
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseService.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseService.kt
@@ -2,7 +2,6 @@ package net.kigawa.keruta.kise
 
 import net.kigawa.keruta.kise.domain.entity.AuthResult
 import net.kigawa.keruta.kise.domain.entity.Session
-import net.kigawa.keruta.kise.domain.entity.UserIdp
 import net.kigawa.keruta.kise.domain.error.KiseErr
 import net.kigawa.keruta.kise.domain.repository.ProviderRepository
 import net.kigawa.keruta.kise.domain.repository.SessionRepository
@@ -17,7 +16,6 @@ import net.kigawa.keruta.kise.usecase.session.LogoutUseCase
 import net.kigawa.keruta.kise.usecase.session.RefreshSessionUseCase
 import net.kigawa.keruta.kise.usecase.session.VerifySessionUseCase
 import net.kigawa.kodel.api.err.Res
-import kotlin.random.Random
 
 /**
  * Kise 認証サービス
@@ -52,19 +50,9 @@ class KiseService(config: KiseConfig) {
     private val logoutUseCase = LogoutUseCase(sessionRepository)
 
     /**
-     * 認証リクエストの入力
-     */
-    data class AuthInput(
-        val userToken: String,
-        val providerToken: String,
-        val defaultUserIdpIssuer: String,
-        val defaultProviderIssuer: String,
-    )
-
-    /**
      * 認証を実行する
      */
-    suspend fun authenticate(input: AuthInput): Res<AuthResult, KiseErr> {
+    suspend fun authenticate(input: AuthenticateUseCase.AuthInput): Res<AuthResult, KiseErr> {
         // Note: 実際のJWT検証は ktcp-sdk の Auth0JwtVerifier を使用するため、
         // ここでは stub 実装を提供します
         return authenticateUseCase.execute(input)

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseService.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseService.kt
@@ -1,0 +1,93 @@
+package net.kigawa.keruta.kise
+
+import net.kigawa.keruta.kise.domain.entity.AuthResult
+import net.kigawa.keruta.kise.domain.entity.Session
+import net.kigawa.keruta.kise.domain.entity.UserIdp
+import net.kigawa.keruta.kise.domain.error.KiseErr
+import net.kigawa.keruta.kise.domain.repository.ProviderRepository
+import net.kigawa.keruta.kise.domain.repository.SessionRepository
+import net.kigawa.keruta.kise.domain.repository.UserRepository
+import net.kigawa.keruta.kise.jwt.JwtIssuerImpl
+import net.kigawa.keruta.kise.persist.repository.ExposedProviderRepository
+import net.kigawa.keruta.kise.persist.repository.ExposedSessionRepository
+import net.kigawa.keruta.kise.persist.repository.ExposedUserRepository
+import net.kigawa.keruta.kise.usecase.auth.AuthenticateUseCase
+import net.kigawa.keruta.kise.usecase.auth.JwtIssuer
+import net.kigawa.keruta.kise.usecase.session.LogoutUseCase
+import net.kigawa.keruta.kise.usecase.session.RefreshSessionUseCase
+import net.kigawa.keruta.kise.usecase.session.VerifySessionUseCase
+import net.kigawa.kodel.api.err.Res
+import kotlin.random.Random
+
+/**
+ * Kise 認証サービス
+ *
+ * すべてのユースケースとリポジトリをまとめたサービス
+ */
+class KiseService(config: KiseConfig) {
+    // リポジトリ
+    private val userRepository: UserRepository = ExposedUserRepository()
+    private val providerRepository: ProviderRepository = ExposedProviderRepository()
+    private val sessionRepository: SessionRepository = ExposedSessionRepository()
+
+    // JWT発行
+    private val jwtIssuer: JwtIssuer = JwtIssuerImpl.fromPem(
+        publicKeyPem = config.jwtPublicKey,
+        privateKeyPem = config.jwtPrivateKey,
+        issuer = config.issuer,
+        audience = config.audience,
+        expiresInMs = config.tokenExpiresInMs
+    )
+
+    // ユースケース
+    private val authenticateUseCase = AuthenticateUseCase(
+        userRepository = userRepository,
+        providerRepository = providerRepository,
+        sessionRepository = sessionRepository,
+        jwtIssuer = jwtIssuer
+    )
+
+    private val verifySessionUseCase = VerifySessionUseCase(sessionRepository)
+    private val refreshSessionUseCase = RefreshSessionUseCase(sessionRepository)
+    private val logoutUseCase = LogoutUseCase(sessionRepository)
+
+    /**
+     * 認証リクエストの入力
+     */
+    data class AuthInput(
+        val userToken: String,
+        val providerToken: String,
+        val defaultUserIdpIssuer: String,
+        val defaultProviderIssuer: String,
+    )
+
+    /**
+     * 認証を実行する
+     */
+    suspend fun authenticate(input: AuthInput): Res<AuthResult, KiseErr> {
+        // Note: 実際のJWT検証は ktcp-sdk の Auth0JwtVerifier を使用するため、
+        // ここでは stub 実装を提供します
+        return authenticateUseCase.execute(input)
+    }
+
+    /**
+     * セッションを検証する
+     */
+    suspend fun verifySession(token: String, currentTime: Long): Res<Session, KiseErr> {
+        return verifySessionUseCase.execute(token, currentTime)
+    }
+
+    /**
+     * セッションを更新する
+     */
+    suspend fun refreshSession(token: String, currentTime: Long): Res<Session, KiseErr> {
+        return refreshSessionUseCase.execute(token, currentTime)
+    }
+
+    /**
+     * ログアウト（セッション削除）
+     */
+    suspend fun logout(token: String): Res<Unit, KiseErr> {
+        return logoutUseCase.execute(token)
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
@@ -1,0 +1,34 @@
+package net.kigawa.keruta.kise.persist
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import net.kigawa.keruta.kise.KiseConfig
+import org.jetbrains.exposed.sql.Database
+
+/**
+ * データベース接続管理
+ */
+object KiseDatabase {
+    private var dataSource: HikariDataSource? = null
+
+    fun connect(config: KiseConfig) {
+        val hikariConfig = HikariConfig().apply {
+            jdbcUrl = config.databaseUrl
+            username = config.databaseUser
+            password = config.databasePassword
+            driverClassName = "com.mysql.cj.jdbc.Driver"
+            maximumPoolSize = 10
+            minimumIdle = 2
+            connectionTimeout = 30000
+            idleTimeout = 600000
+            maxLifetime = 1800000
+        }
+
+        dataSource = HikariDataSource(hikariConfig)
+        Database.connect(dataSource!!)
+    }
+
+    fun close() {
+        dataSource?.close()
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
@@ -3,25 +3,34 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Provider
 import net.kigawa.keruta.kise.domain.repository.ProviderRepository
 import net.kigawa.keruta.kise.persist.table.ProviderTable
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * Exposed を使用したプロバイダーリポジトリ実装
  */
 class ExposedProviderRepository : ProviderRepository {
     override suspend fun getById(id: Long): Provider? {
-        val row = ProviderTable.select { ProviderTable.id eq id }.firstOrNull() ?: return null
+        val row = ProviderTable
+            .selectAll()
+            .where { ProviderTable.id eq id }
+            .firstOrNull() ?: return null
         return rowToProvider(row)
     }
 
     override suspend fun getByIssuer(issuer: String): Provider? {
-        val row = ProviderTable.select { ProviderTable.issuer eq issuer }.firstOrNull() ?: return null
+        val row = ProviderTable
+            .selectAll()
+            .where { ProviderTable.issuer eq issuer }
+            .firstOrNull() ?: return null
         return rowToProvider(row)
     }
 
     override suspend fun getByUserId(userId: Long): List<Provider> {
-        return ProviderTable.select { ProviderTable.userId eq userId }
+        return ProviderTable
+            .selectAll()
+            .where { ProviderTable.userId eq userId }
             .map { rowToProvider(it) }
     }
 

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
@@ -1,0 +1,56 @@
+package net.kigawa.keruta.kise.persist.repository
+
+import net.kigawa.keruta.kise.domain.entity.Provider
+import net.kigawa.keruta.kise.domain.repository.ProviderRepository
+import net.kigawa.keruta.kise.persist.table.ProviderTable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+
+/**
+ * Exposed を使用したプロバイダーリポジトリ実装
+ */
+class ExposedProviderRepository : ProviderRepository {
+    override suspend fun getById(id: Long): Provider? {
+        val row = ProviderTable.select { ProviderTable.id eq id }.firstOrNull() ?: return null
+        return rowToProvider(row)
+    }
+
+    override suspend fun getByIssuer(issuer: String): Provider? {
+        val row = ProviderTable.select { ProviderTable.issuer eq issuer }.firstOrNull() ?: return null
+        return rowToProvider(row)
+    }
+
+    override suspend fun getByUserId(userId: Long): List<Provider> {
+        return ProviderTable.select { ProviderTable.userId eq userId }
+            .map { rowToProvider(it) }
+    }
+
+    override suspend fun create(provider: Provider): Provider {
+        val now = System.currentTimeMillis()
+        val id = ProviderTable.insert {
+            it[userId] = provider.userId
+            it[name] = provider.name
+            it[issuer] = provider.issuer
+            it[audience] = provider.audience
+            it[setting] = provider.setting
+            it[createdAt] = now
+        } get ProviderTable.id
+
+        return provider.copy(
+            id = id,
+            createdAt = now
+        )
+    }
+
+    private fun rowToProvider(row: org.jetbrains.exposed.sql.ResultRow): Provider {
+        return Provider(
+            id = row[ProviderTable.id],
+            userId = row[ProviderTable.userId],
+            name = row[ProviderTable.name],
+            issuer = row[ProviderTable.issuer],
+            audience = row[ProviderTable.audience],
+            setting = row[ProviderTable.setting],
+            createdAt = row[ProviderTable.createdAt]
+        )
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
@@ -1,0 +1,72 @@
+package net.kigawa.keruta.kise.persist.repository
+
+import net.kigawa.keruta.kise.domain.entity.Session
+import net.kigawa.keruta.kise.domain.repository.SessionRepository
+import net.kigawa.keruta.kise.persist.table.SessionTable
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+
+/**
+ * Exposed を使用したセッションリポジトリ実装
+ */
+class ExposedSessionRepository : SessionRepository {
+    override suspend fun create(session: Session): Session {
+        val now = System.currentTimeMillis()
+        val id = SessionTable.insert {
+            it[userId] = session.userId
+            it[token] = session.token
+            it[expiresAt] = session.expiresAt
+            it[createdAt] = now
+            it[updatedAt] = now
+        } get SessionTable.id
+
+        return session.copy(
+            id = id,
+            createdAt = now,
+            updatedAt = now
+        )
+    }
+
+    override suspend fun getByToken(token: String): Session? {
+        val row = SessionTable.select { SessionTable.token eq token }.firstOrNull() ?: return null
+
+        return Session(
+            id = row[SessionTable.id],
+            userId = row[SessionTable.userId],
+            token = row[SessionTable.token],
+            expiresAt = row[SessionTable.expiresAt],
+            createdAt = row[SessionTable.createdAt],
+            updatedAt = row[SessionTable.updatedAt]
+        )
+    }
+
+    override suspend fun getByUserId(userId: Long): List<Session> {
+        return SessionTable.select { SessionTable.userId eq userId }
+            .map { row ->
+                Session(
+                    id = row[SessionTable.id],
+                    userId = row[SessionTable.userId],
+                    token = row[SessionTable.token],
+                    expiresAt = row[SessionTable.expiresAt],
+                    createdAt = row[SessionTable.createdAt],
+                    updatedAt = row[SessionTable.updatedAt]
+                )
+            }
+    }
+
+    override suspend fun deleteByToken(token: String) {
+        SessionTable.deleteWhere { SessionTable.token eq token }
+    }
+
+    override suspend fun deleteExpired(userId: Long) {
+        val now = System.currentTimeMillis()
+        SessionTable.deleteWhere {
+            (SessionTable.userId eq userId) and (SessionTable.expiresAt less now)
+        }
+    }
+
+    override suspend fun countByUserId(userId: Long): Int {
+        return SessionTable.select { SessionTable.userId eq userId }.count().toInt()
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
@@ -3,9 +3,12 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Session
 import net.kigawa.keruta.kise.domain.repository.SessionRepository
 import net.kigawa.keruta.kise.persist.table.SessionTable
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * Exposed を使用したセッションリポジトリ実装
@@ -29,7 +32,10 @@ class ExposedSessionRepository : SessionRepository {
     }
 
     override suspend fun getByToken(token: String): Session? {
-        val row = SessionTable.select { SessionTable.token eq token }.firstOrNull() ?: return null
+        val row = SessionTable
+            .selectAll()
+            .where { SessionTable.token eq token }
+            .firstOrNull() ?: return null
 
         return Session(
             id = row[SessionTable.id],
@@ -42,7 +48,9 @@ class ExposedSessionRepository : SessionRepository {
     }
 
     override suspend fun getByUserId(userId: Long): List<Session> {
-        return SessionTable.select { SessionTable.userId eq userId }
+        return SessionTable
+            .selectAll()
+            .where { SessionTable.userId eq userId }
             .map { row ->
                 Session(
                     id = row[SessionTable.id],
@@ -67,6 +75,10 @@ class ExposedSessionRepository : SessionRepository {
     }
 
     override suspend fun countByUserId(userId: Long): Int {
-        return SessionTable.select { SessionTable.userId eq userId }.count().toInt()
+        return SessionTable
+            .selectAll()
+            .where { SessionTable.userId eq userId }
+            .count()
+            .toInt()
     }
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
@@ -1,0 +1,75 @@
+package net.kigawa.keruta.kise.persist.repository
+
+import net.kigawa.keruta.kise.domain.entity.User
+import net.kigawa.keruta.kise.domain.entity.UserIdp
+import net.kigawa.keruta.kise.domain.repository.UserRepository
+import net.kigawa.keruta.kise.persist.table.UserIdpTable
+import net.kigawa.keruta.kise.persist.table.UserTable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+
+/**
+ * Exposed を使用したユーザーリポジトリ実装
+ */
+class ExposedUserRepository : UserRepository {
+    override suspend fun create(): User {
+        val now = System.currentTimeMillis()
+        val id = UserTable.insert {
+            it[createdAt] = now
+        } get UserTable.id
+        return User(id = id, createdAt = now)
+    }
+
+    override suspend fun getById(id: Long): User? {
+        val row = UserTable.select { UserTable.id eq id }.firstOrNull() ?: return null
+        return User(
+            id = row[UserTable.id],
+            createdAt = row[UserTable.createdAt]
+        )
+    }
+
+    override suspend fun getUserIdp(userId: Long, issuer: String, subject: String): UserIdp? {
+        val row = UserIdpTable.select {
+            (UserIdpTable.userId eq userId) and
+                (UserIdpTable.issuer eq issuer) and
+                (UserIdpTable.subject eq subject)
+        }.firstOrNull() ?: return null
+
+        return UserIdp(
+            userId = row[UserIdpTable.userId],
+            providerId = row[UserIdpTable.providerId],
+            issuer = row[UserIdpTable.issuer],
+            subject = row[UserIdpTable.subject],
+            audience = row[UserIdpTable.audience],
+            createdAt = row[UserIdpTable.createdAt]
+        )
+    }
+
+    override suspend fun getUserIdpByIdentity(issuer: String, subject: String): UserIdp? {
+        val row = UserIdpTable.select {
+            (UserIdpTable.issuer eq issuer) and (UserIdpTable.subject eq subject)
+        }.firstOrNull() ?: return null
+
+        return UserIdp(
+            userId = row[UserIdpTable.userId],
+            providerId = row[UserIdpTable.providerId],
+            issuer = row[UserIdpTable.issuer],
+            subject = row[UserIdpTable.subject],
+            audience = row[UserIdpTable.audience],
+            createdAt = row[UserIdpTable.createdAt]
+        )
+    }
+
+    override suspend fun createUserIdp(userIdp: UserIdp): UserIdp {
+        val now = System.currentTimeMillis()
+        UserIdpTable.insert {
+            it[userId] = userIdp.userId
+            it[providerId] = userIdp.providerId
+            it[issuer] = userIdp.issuer
+            it[subject] = userIdp.subject
+            it[audience] = userIdp.audience
+            it[createdAt] = now
+        }
+        return userIdp.copy(createdAt = now)
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
@@ -5,8 +5,10 @@ import net.kigawa.keruta.kise.domain.entity.UserIdp
 import net.kigawa.keruta.kise.domain.repository.UserRepository
 import net.kigawa.keruta.kise.persist.table.UserIdpTable
 import net.kigawa.keruta.kise.persist.table.UserTable
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * Exposed を使用したユーザーリポジトリ実装
@@ -21,7 +23,10 @@ class ExposedUserRepository : UserRepository {
     }
 
     override suspend fun getById(id: Long): User? {
-        val row = UserTable.select { UserTable.id eq id }.firstOrNull() ?: return null
+        val row = UserTable
+            .selectAll()
+            .where { UserTable.id eq id }
+            .firstOrNull() ?: return null
         return User(
             id = row[UserTable.id],
             createdAt = row[UserTable.createdAt]
@@ -29,11 +34,14 @@ class ExposedUserRepository : UserRepository {
     }
 
     override suspend fun getUserIdp(userId: Long, issuer: String, subject: String): UserIdp? {
-        val row = UserIdpTable.select {
-            (UserIdpTable.userId eq userId) and
-                (UserIdpTable.issuer eq issuer) and
-                (UserIdpTable.subject eq subject)
-        }.firstOrNull() ?: return null
+        val row = UserIdpTable
+            .selectAll()
+            .where {
+                (UserIdpTable.userId eq userId) and
+                    (UserIdpTable.issuer eq issuer) and
+                    (UserIdpTable.subject eq subject)
+            }
+            .firstOrNull() ?: return null
 
         return UserIdp(
             userId = row[UserIdpTable.userId],
@@ -46,9 +54,12 @@ class ExposedUserRepository : UserRepository {
     }
 
     override suspend fun getUserIdpByIdentity(issuer: String, subject: String): UserIdp? {
-        val row = UserIdpTable.select {
-            (UserIdpTable.issuer eq issuer) and (UserIdpTable.subject eq subject)
-        }.firstOrNull() ?: return null
+        val row = UserIdpTable
+            .selectAll()
+            .where {
+                (UserIdpTable.issuer eq issuer) and (UserIdpTable.subject eq subject)
+            }
+            .firstOrNull() ?: return null
 
         return UserIdp(
             userId = row[UserIdpTable.userId],

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
@@ -1,0 +1,17 @@
+package net.kigawa.keruta.kise.persist.table
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * プロバイダーテーブル
+ */
+object ProviderTable : Table("kise_provider") {
+    val id = long("id").autoIncrement()
+    val userId = long("user_id").references(UserTable.id)
+    val name = varchar("name", 50)
+    val issuer = varchar("issuer", 255)
+    val audience = varchar("audience", 255)
+    val setting = text("setting")
+    val createdAt = long("created_at")
+    override val primaryKey = PrimaryKey(id)
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
@@ -1,0 +1,16 @@
+package net.kigawa.keruta.kise.persist.table
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * セッションンテーブル
+ */
+object SessionTable : Table("kise_session") {
+    val id = long("id").autoIncrement()
+    val userId = long("user_id").references(UserTable.id)
+    val token = varchar("token", 512)
+    val expiresAt = long("expires_at")
+    val createdAt = long("created_at")
+    val updatedAt = long("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
@@ -1,0 +1,16 @@
+package net.kigawa.keruta.kise.persist.table
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * ユーザーIdP関連付けテーブル
+ */
+object UserIdpTable : Table("kise_user_idp") {
+    val userId = long("user_id").references(UserTable.id)
+    val providerId = long("provider_id").references(ProviderTable.id)
+    val issuer = varchar("issuer", 255)
+    val subject = varchar("subject", 255)
+    val audience = varchar("audience", 255)
+    val createdAt = long("created_at")
+    override val primaryKey = PrimaryKey(userId, issuer, subject)
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
@@ -1,0 +1,12 @@
+package net.kigawa.keruta.kise.persist.table
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * ユーザーテーブル
+ */
+object UserTable : Table("kise_user") {
+    val id = long("id").autoIncrement()
+    val createdAt = long("created_at")
+    override val primaryKey = PrimaryKey(id)
+}


### PR DESCRIPTION
# 概要
kise（Keruta ID Server）モジュールをinfra層として追加し、認証機能と永続化層の基盤を実装しました。

## 背景・目的
- 現在のktse認証機能をkiseモジュールとして分離・統合するため
- 将来的に複数のサービス（ktse, ktcl-k8s, kicl-web）で统一された認証メカニズムを提供
- KICP（クロスドメインIDフェデレーション）対応のため

## 変更内容
### モジュール追加
- kise モジュール構造を追加（domain, usecase, server）
- settings.gradle.kts を更新してkiseモジュールを追加
- CIワークフローを追加（kise-check.yml, kise-dev.yml）

### Domainレイヤー
- エンティティ: User, Provider, Session, UserIdp
- エラー型: KiseErr 階層（InvalidTokenErr, SessionNotFoundErrなど）
- リポジトリインターフェース: UserRepository, ProviderRepository, SessionRepository

### Usecaseレイヤー
- AuthenticateUseCase: 認証ユースケース
- VerifySessionUseCase: セッション検証
- RefreshSessionUseCase: セッション更新
- LogoutUseCase: ログアウト

### Serverレイヤー
- KiseConfig: 設定管理（JWT鍵、データベース接続など）
- JwtIssuerImpl: JWT発行（RSA256）
- KiseWebSocketServer: WebSocketサーバーモジュール
- KiseService: 全コンポーネントをまとめたサービス

### Persistレイヤー（実装完了）
- Exposedテーブル: kise_user, kise_provider, kise_session, kise_user_idp
- リポジトリ実装: ExposedUserRepository, ExposedSessionRepository, ExposedProviderRepository
- Database: HikariCPを使用した接続管理

## 確認方法
```bash
./gradlew :kise:domain:compileKotlinJvm :kise:usecase:compileKotlinJvm
```

## その他
- 現在の実装はスタブ（ktcp-sdk の Auth0JwtVerifier と統合必要）
- データベース永続化の実装は完了
- 将来的にktseを更新してkiseを使用するように変更予定
- iOS编译問題を回避するためJVMターゲットの実装のみ