### PR TITLE
fix: replace deprecated enable-configuration-cache with cache-disabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         if: inputs.gradleTask != ''
         with:
-          enable-configuration-cache: true
+          cache-disabled: false
       - name: Gradle cache
         if: inputs.gradleTask != ''
         uses: actions/cache@v5


### PR DESCRIPTION
# タイトル
fix: replace deprecated enable-configuration-cache with cache-disabled in release workflow

## 概要
GitHub ActionsのGradle Setupアクションで使用されていた非推奨パラメータ `enable-configuration-cache` を有効なパラメータ `cache-disabled: false` に替换えました。

## 背景・目的
GitHub Actions実行時に以下の警告が発生していました:
```
Unexpected input(s) 'enable-configuration-cache', valid inputs are [...]
```

`gradle/actions/setup-gradle@v6` は `enable-configuration-cache` パラメータを认识しなくなったため、この警告を解決する必要があります。

## 変更内容
- `.github/workflows/release.yml`:
  - `enable-configuration-cache: true` → `cache-disabled: false`

## 確認方法
GitHub Actionsが警告なく成功することを確認してください。

## その他
メインのエラー（HarborへのDockerプッシュ失敗）はこの変更の対象外です。別の問題입니다.