### PR TITLE
fix(kise): Exposed 1.x importの修正とktse-sdk依存関係の追加

### DIFF
--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -18,10 +18,14 @@ kotlin {
         api(project(":ktcp-sdk:ktcp-domain:ktcp-domain-server"))
         api(project(":ktcp-sdk:ktcp-domain"))
         // Database
-        implementation("org.jetbrains.exposed:exposed-core:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-dao:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-jdbc:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-kotlin-datetime:0.61.0")
+        implementation("org.jetbrains.exposed:exposed-core:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-dao:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-jdbc:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-kotlin-datetime:${Version.EXPOSED}")
+        // Auth dependencies - for Auth0JwtVerifier in ktcp-sdk/src/jvmMain
+        api(project(":ktcp-sdk"))
+        // For UnverifiedAuthTokens, AuthTokenDecoder interface
+        api(project(":ktse-sdk"))
         implementation("com.mysql:mysql-connector-j:9.7.0")
         implementation("com.zaxxer:HikariCP:7.0.2")
     }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/AuthTokenDecoderImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/AuthTokenDecoderImpl.kt
@@ -1,0 +1,34 @@
+package net.kigawa.keruta.kise.auth
+
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifier
+import net.kigawa.keruta.ktcp.domain.auth.request.ServerAuthRequestMsg
+import net.kigawa.keruta.ktcp.domain.err.KtcpErr
+import net.kigawa.keruta.ktcp.server.auth.UnverifiedAuthTokens
+import net.kigawa.keruta.ktcp.server.auth.jwt.AuthTokenDecoder
+import net.kigawa.kodel.api.err.Res
+
+class AuthTokenDecoderImpl(
+    val jwtVerifier: JwtVerifier,
+): AuthTokenDecoder {
+    override fun decodeAuthRequestMsg(authRequestMsg: ServerAuthRequestMsg): Res<UnverifiedAuthTokens, KtcpErr> {
+        val unverifiedUserToken = when (
+            val res = jwtVerifier.decodeUnverified(authRequestMsg.userToken)
+        ) {
+            is Res.Err -> return res.convert()
+            is Res.Ok -> res.value
+        }
+        val unverifiedProviderToken = when (
+            val res = jwtVerifier.decodeUnverified(
+                authRequestMsg.serverToken
+            )
+        ) {
+            is Res.Err -> return res.convert()
+            is Res.Ok -> res.value
+        }
+        return Res.Ok(
+            UnverifiedAuthTokens(
+                unverifiedUserToken, unverifiedProviderToken
+            )
+        )
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/JwtVerifierImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/JwtVerifierImpl.kt
@@ -1,0 +1,42 @@
+package net.kigawa.keruta.kise.auth
+
+import com.auth0.jwt.JWT
+import net.kigawa.keruta.ktcp.base.auth.VerifyFailErr
+import net.kigawa.keruta.ktcp.base.auth.jwt.Auth0JwtVerifier
+import net.kigawa.keruta.ktcp.base.auth.key.Auth0AlgorithmInitializer
+import net.kigawa.keruta.ktcp.base.auth.key.JavaKeyPairInitializer
+import net.kigawa.keruta.ktcp.domain.auth.AuthToken
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifier
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifyValues
+import net.kigawa.keruta.ktcp.domain.auth.jwt.UnverifiedToken
+import net.kigawa.keruta.ktcp.domain.auth.jwt.VerifyErr
+import net.kigawa.keruta.ktcp.domain.auth.key.PemKey
+import net.kigawa.keruta.ktcp.domain.err.KtcpErr
+import net.kigawa.kodel.api.err.Res
+import java.util.*
+
+class JwtVerifierImpl(
+    private val auth0JwtVerifier: Auth0JwtVerifier,
+    private val pemKey: PemKey,
+    val auth0AlgorithmInitializer: Auth0AlgorithmInitializer,
+    val javaKeyPairInitializer: JavaKeyPairInitializer,
+): JwtVerifier {
+
+    override fun decodeUnverified(userToken: AuthToken): Res<UnverifiedToken, VerifyErr> =
+        auth0JwtVerifier.decodeUnverified(userToken)
+
+    override fun createToken(jwtVerifyValues: JwtVerifyValues): Res<AuthToken, KtcpErr> = try {
+        val algorithm = auth0AlgorithmInitializer.initPrivateKey(
+            javaKeyPairInitializer.initialize(pemKey)
+        )
+        val token = JWT.create()
+            .withIssuer(jwtVerifyValues.issuer.toStrUrl())
+            .withAudience(jwtVerifyValues.audience)
+            .withSubject(jwtVerifyValues.subject)
+            .withExpiresAt(Date(System.currentTimeMillis() + 3_600_000))
+            .sign(algorithm)
+        Res.Ok(token)
+    } catch (e: Exception) {
+        Res.Err(VerifyFailErr("JWT creation failed: ${e.message}", e))
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/model/TokenExchangeResponse.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/model/TokenExchangeResponse.kt
@@ -1,0 +1,16 @@
+package net.kigawa.keruta.kise.auth.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonIgnoreUnknownKeys
+data class TokenExchangeResponse(
+    @SerialName("id_token")
+    val idToken: String? = null,
+    @SerialName("access_token")
+    val accessToken: String? = null,
+)

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
@@ -3,7 +3,7 @@ package net.kigawa.keruta.kise.persist
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import net.kigawa.keruta.kise.KiseConfig
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
  * データベース接続管理

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
@@ -3,9 +3,10 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Provider
 import net.kigawa.keruta.kise.domain.repository.ProviderRepository
 import net.kigawa.keruta.kise.persist.table.ProviderTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.core.ResultRow
 
 /**
  * Exposed を使用したプロバイダーリポジトリ実装
@@ -51,7 +52,7 @@ class ExposedProviderRepository : ProviderRepository {
         )
     }
 
-    private fun rowToProvider(row: org.jetbrains.exposed.sql.ResultRow): Provider {
+    private fun rowToProvider(row: ResultRow): Provider {
         return Provider(
             id = row[ProviderTable.id],
             userId = row[ProviderTable.userId],

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
@@ -3,12 +3,12 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Session
 import net.kigawa.keruta.kise.domain.repository.SessionRepository
 import net.kigawa.keruta.kise.persist.table.SessionTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 
 /**
  * Exposed を使用したセッションリポジトリ実装

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
@@ -5,10 +5,10 @@ import net.kigawa.keruta.kise.domain.entity.UserIdp
 import net.kigawa.keruta.kise.domain.repository.UserRepository
 import net.kigawa.keruta.kise.persist.table.UserIdpTable
 import net.kigawa.keruta.kise.persist.table.UserTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 
 /**
  * Exposed を使用したユーザーリポジトリ実装

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * プロバイダーテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * セッションンテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * ユーザーIdP関連付けテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * ユーザーテーブル


### PR DESCRIPTION
# タイトル
fix(kise): Exposed 1.x importの修正とktse-sdk依存関係の追加

## 概要
kise persist層のExposed importを1.x形式（org.jetbrains.exposed.v1.*）に修正し、認証機能のためにktse-sdkへの依存関係を追加しました。

## 背景・目的
kiseモジュールのJVMターゲットコンパイル時に、Exposed 0.x形式のimport（org.jetbrains.exposed.sql.*） 导致错误。ktseではExposed 1.x（org.jetbrains.exposed.v1.*）を 使用しているため、kiseも同様に统一する必要があります。

## 変更内容
- **Tableファイル**: `org.jetbrains.exposed.sql.Table` → `org.jetbrains.exposed.v1.core.Table`
- **Repositoryファイル**: 
  - `org.jetbrains.exposed.sql.*` → `org.jetbrains.exposed.v1.core.*` (eq, and, less)
  - `org.jetbrains.exposed.sql.insert/selectAll/deleteWhere` → `org.jetbrains.exposed.v1.jdbc.*`
- **Database.kt**: `org.jetbrains.exposed.sql.Database` → `org.jetbrains.exposed.v1.jdbc.Database`
- **build.gradle.kts**: ktse-sdk依存関係を追加（UnverifiedAuthTokens、AuthTokenDecoderインターフェース用）
- **authファイル**: ktseからコピー（JwtVerifierImpl、AuthTokenDecoderImpl、TokenExchangeResponse）

## 確認方法
```bash
./gradlew :kise:compileKotlinJvm  # 成功することを確認
./gradlew :ktse:compileKotlin      # 既存コードに影響がないことを確認
```

## その他
- kise JVMコンパイル: ✅ 成功
- ktseコンパイル: ✅ 成功（影響なし）