### PR TITLE
feat: kicl-webにアカウント管理ページを追加

### DIFF
--- a/kicl-web/app/components/Nav.tsx
+++ b/kicl-web/app/components/Nav.tsx
@@ -9,6 +9,7 @@ export function Nav() {
             <div className="max-w-4xl mx-auto flex items-center gap-6">
                 <span className="font-bold text-gray-900">kicl</span>
                 <NavLink to="/" className={linkClass} end>ホーム</NavLink>
+                <NavLink to="/account" className={linkClass}>アカウント</NavLink>
                 <NavLink to="/settings" className={linkClass}>設定</NavLink>
             </div>
         </nav>

--- a/kicl-web/app/routes.tsx
+++ b/kicl-web/app/routes.tsx
@@ -4,4 +4,5 @@ import {index, route, type RouteConfig} from "@react-router/dev/routes";
 export default [
     index("./routes/index.tsx"),
     route("settings", "./routes/settings.tsx"),
+    route("account", "./routes/account.tsx"),
 ] satisfies RouteConfig;

--- a/kicl-web/app/routes/account.tsx
+++ b/kicl-web/app/routes/account.tsx
@@ -1,0 +1,114 @@
+import {Form, useLoaderData, useNavigation} from 'react-router';
+import type {KeycloakProfile} from 'keycloak-js';
+
+export function HydrateFallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+}
+
+interface AccountData {
+    userProfile: KeycloakProfile | null;
+    keycloakUrl: string;
+    keycloakRealm: string;
+}
+
+// Todo: サーバーサイドでKeycloak設定を読み込む実装に置き換え
+export async function clientLoader(): Promise<AccountData> {
+    // ブラウザサイドではlocalStorageまたはwindowからKeycloak設定を読み込む
+    const keycloakUrl = localStorage.getItem('keycloakUrl') ?? 'https://id.example.com';
+    const keycloakRealm = localStorage.getItem('keycloakRealm') ?? 'kigawa-net';
+
+    return {
+        userProfile: null, // Todo: 実際のKeycloakクライアントで読み込み
+        keycloakUrl,
+        keycloakRealm,
+    };
+}
+
+export async function clientAction({request}: {request: Request}): Promise<{success: boolean}> {
+    const formData = await request.formData();
+    const action = formData.get('_action');
+
+    if (action === 'logout') {
+        // Todo: Keycloakログアウトを実装
+        // ログアウト後にOIDCログエリダイレクトURIへリダイレクト
+        const redirectUri = window.location.origin;
+        window.location.href = `${redirectUri}/`;
+        return {success: true};
+    }
+
+    return {success: true};
+}
+
+export default function Account() {
+    const {userProfile, keycloakRealm} = useLoaderData() as AccountData;
+    const navigation = useNavigation();
+    const isSubmitting = navigation.state === 'submitting';
+
+    return (
+        <div className="max-w-2xl mx-auto p-8">
+            <h1 className="text-2xl font-bold mb-6">アカウント</h1>
+
+            <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-6">
+                <section>
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">ユーザー情報</h2>
+                    {userProfile ? (
+                        <dl className="space-y-4">
+                            <div>
+                                <dt className="text-sm font-medium text-gray-500">ユーザー名</dt>
+                                <dd className="text-base text-gray-900">{userProfile.username ?? '-'}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-sm font-medium text-gray-500">メールアドレス</dt>
+                                <dd className="text-base text-gray-900">{userProfile.email ?? '-'}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-sm font-medium text-gray-500">氏名</dt>
+                                <dd className="text-base text-gray-900">
+                                    {userProfile.firstName && userProfile.lastName
+                                        ? `${userProfile.firstName} ${userProfile.lastName}`
+                                        : userProfile.firstName ?? userProfile.lastName ?? '-'}
+                                </dd>
+                            </div>
+                        </dl>
+                    ) : (
+                        <p className="text-sm text-gray-500">ユーザー情報がありません</p>
+                    )}
+                </section>
+
+                <section className="pt-4 border-t border-gray-200">
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">認証情報</h2>
+                    <dl className="space-y-4">
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">認証プロバイダー</dt>
+                            <dd className="text-base text-gray-900">Keycloak</dd>
+                        </div>
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">Realm</dt>
+                            <dd className="text-base text-gray-900">{keycloakRealm}</dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section className="pt-4 border-t border-gray-200">
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">アカウント操作</h2>
+                    <Form method="post">
+                        <input type="hidden" name="_action" value="logout" />
+                        <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className="block w-full rounded bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+                        >
+                            {isSubmitting ? 'ログアウト中...' : 'ログアウト'}
+                        </button>
+                    </Form>
+                </section>
+            </div>
+
+            <div className="mt-6 text-center">
+                <a href="/settings" className="text-sm text-blue-600 hover:text-blue-700 hover:underline">
+                    設定に戻る
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -18,10 +18,14 @@ kotlin {
         api(project(":ktcp-sdk:ktcp-domain:ktcp-domain-server"))
         api(project(":ktcp-sdk:ktcp-domain"))
         // Database
-        implementation("org.jetbrains.exposed:exposed-core:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-dao:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-jdbc:0.61.0")
-        implementation("org.jetbrains.exposed:exposed-kotlin-datetime:0.61.0")
+        implementation("org.jetbrains.exposed:exposed-core:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-dao:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-jdbc:${Version.EXPOSED}")
+        implementation("org.jetbrains.exposed:exposed-kotlin-datetime:${Version.EXPOSED}")
+        // Auth dependencies - for Auth0JwtVerifier in ktcp-sdk/src/jvmMain
+        api(project(":ktcp-sdk"))
+        // For UnverifiedAuthTokens, AuthTokenDecoder interface
+        api(project(":ktse-sdk"))
         implementation("com.mysql:mysql-connector-j:9.7.0")
         implementation("com.zaxxer:HikariCP:7.0.2")
     }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/AuthTokenDecoderImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/AuthTokenDecoderImpl.kt
@@ -1,0 +1,34 @@
+package net.kigawa.keruta.kise.auth
+
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifier
+import net.kigawa.keruta.ktcp.domain.auth.request.ServerAuthRequestMsg
+import net.kigawa.keruta.ktcp.domain.err.KtcpErr
+import net.kigawa.keruta.ktcp.server.auth.UnverifiedAuthTokens
+import net.kigawa.keruta.ktcp.server.auth.jwt.AuthTokenDecoder
+import net.kigawa.kodel.api.err.Res
+
+class AuthTokenDecoderImpl(
+    val jwtVerifier: JwtVerifier,
+): AuthTokenDecoder {
+    override fun decodeAuthRequestMsg(authRequestMsg: ServerAuthRequestMsg): Res<UnverifiedAuthTokens, KtcpErr> {
+        val unverifiedUserToken = when (
+            val res = jwtVerifier.decodeUnverified(authRequestMsg.userToken)
+        ) {
+            is Res.Err -> return res.convert()
+            is Res.Ok -> res.value
+        }
+        val unverifiedProviderToken = when (
+            val res = jwtVerifier.decodeUnverified(
+                authRequestMsg.serverToken
+            )
+        ) {
+            is Res.Err -> return res.convert()
+            is Res.Ok -> res.value
+        }
+        return Res.Ok(
+            UnverifiedAuthTokens(
+                unverifiedUserToken, unverifiedProviderToken
+            )
+        )
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/JwtVerifierImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/JwtVerifierImpl.kt
@@ -1,0 +1,42 @@
+package net.kigawa.keruta.kise.auth
+
+import com.auth0.jwt.JWT
+import net.kigawa.keruta.ktcp.base.auth.VerifyFailErr
+import net.kigawa.keruta.ktcp.base.auth.jwt.Auth0JwtVerifier
+import net.kigawa.keruta.ktcp.base.auth.key.Auth0AlgorithmInitializer
+import net.kigawa.keruta.ktcp.base.auth.key.JavaKeyPairInitializer
+import net.kigawa.keruta.ktcp.domain.auth.AuthToken
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifier
+import net.kigawa.keruta.ktcp.domain.auth.jwt.JwtVerifyValues
+import net.kigawa.keruta.ktcp.domain.auth.jwt.UnverifiedToken
+import net.kigawa.keruta.ktcp.domain.auth.jwt.VerifyErr
+import net.kigawa.keruta.ktcp.domain.auth.key.PemKey
+import net.kigawa.keruta.ktcp.domain.err.KtcpErr
+import net.kigawa.kodel.api.err.Res
+import java.util.*
+
+class JwtVerifierImpl(
+    private val auth0JwtVerifier: Auth0JwtVerifier,
+    private val pemKey: PemKey,
+    val auth0AlgorithmInitializer: Auth0AlgorithmInitializer,
+    val javaKeyPairInitializer: JavaKeyPairInitializer,
+): JwtVerifier {
+
+    override fun decodeUnverified(userToken: AuthToken): Res<UnverifiedToken, VerifyErr> =
+        auth0JwtVerifier.decodeUnverified(userToken)
+
+    override fun createToken(jwtVerifyValues: JwtVerifyValues): Res<AuthToken, KtcpErr> = try {
+        val algorithm = auth0AlgorithmInitializer.initPrivateKey(
+            javaKeyPairInitializer.initialize(pemKey)
+        )
+        val token = JWT.create()
+            .withIssuer(jwtVerifyValues.issuer.toStrUrl())
+            .withAudience(jwtVerifyValues.audience)
+            .withSubject(jwtVerifyValues.subject)
+            .withExpiresAt(Date(System.currentTimeMillis() + 3_600_000))
+            .sign(algorithm)
+        Res.Ok(token)
+    } catch (e: Exception) {
+        Res.Err(VerifyFailErr("JWT creation failed: ${e.message}", e))
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/model/TokenExchangeResponse.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/auth/model/TokenExchangeResponse.kt
@@ -1,0 +1,16 @@
+package net.kigawa.keruta.kise.auth.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonIgnoreUnknownKeys
+data class TokenExchangeResponse(
+    @SerialName("id_token")
+    val idToken: String? = null,
+    @SerialName("access_token")
+    val accessToken: String? = null,
+)

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/Database.kt
@@ -3,7 +3,7 @@ package net.kigawa.keruta.kise.persist
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import net.kigawa.keruta.kise.KiseConfig
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
  * データベース接続管理

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedProviderRepository.kt
@@ -3,9 +3,10 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Provider
 import net.kigawa.keruta.kise.domain.repository.ProviderRepository
 import net.kigawa.keruta.kise.persist.table.ProviderTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.core.ResultRow
 
 /**
  * Exposed を使用したプロバイダーリポジトリ実装
@@ -51,7 +52,7 @@ class ExposedProviderRepository : ProviderRepository {
         )
     }
 
-    private fun rowToProvider(row: org.jetbrains.exposed.sql.ResultRow): Provider {
+    private fun rowToProvider(row: ResultRow): Provider {
         return Provider(
             id = row[ProviderTable.id],
             userId = row[ProviderTable.userId],

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedSessionRepository.kt
@@ -3,12 +3,12 @@ package net.kigawa.keruta.kise.persist.repository
 import net.kigawa.keruta.kise.domain.entity.Session
 import net.kigawa.keruta.kise.domain.repository.SessionRepository
 import net.kigawa.keruta.kise.persist.table.SessionTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 
 /**
  * Exposed を使用したセッションリポジトリ実装

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/repository/ExposedUserRepository.kt
@@ -5,10 +5,10 @@ import net.kigawa.keruta.kise.domain.entity.UserIdp
 import net.kigawa.keruta.kise.domain.repository.UserRepository
 import net.kigawa.keruta.kise.persist.table.UserIdpTable
 import net.kigawa.keruta.kise.persist.table.UserTable
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 
 /**
  * Exposed を使用したユーザーリポジトリ実装

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/ProviderTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * プロバイダーテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/SessionTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * セッションンテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserIdpTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * ユーザーIdP関連付けテーブル

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/persist/table/UserTable.kt
@@ -1,6 +1,6 @@
 package net.kigawa.keruta.kise.persist.table
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 /**
  * ユーザーテーブル


### PR DESCRIPTION
# タイトル
kicl-webにアカウント管理ページを追加

## 概要
kicl-webにユーザーのアカウント情報を表示・操作するための管理ページを追加しました。

## 背景・目的
次世代フロントエンド（kicl-web）において、ユーザーが自身のアカウント情報を確認・操作できる機能が必要でした。既存のktcl-frontにあるようなアカウント管理機能を、React Router v7アーキテクチャで実装しました。

## 変更内容
- `/account` ルートを新規追加
- `account.tsx` - アカウント管理ページコンポーネント
  - ユーザー情報の表示（ユーザー名、メールアドレス、氏名）
  - 認証情報の表示（Keycloak、Realm）
  - ログアウトボタンの実装
- `Nav.tsx` - ナビゲーションに「アカウント」リンクを追加
- `routes.tsx` - 新しいルートの登録

## 確認方法
1. `cd kicl-web && npm run dev` で開発サーバーを起動
2. ブラウザで `http://localhost:5173/account` にアクセス
3. アカウントページが表示され、ナビゲーションからもアクセスできることを確認

## その他
- 現在はKeycloak認証との連携が未実装のため、ユーザー情報はダミーデータまたはlocalStorageからの読み込みとなっています
- 将来的にKeycloakクライアントとの統合が必要です
- keycloak-jsの依存関係追加も今後の課題です