### PR TITLE
feat: docファイル名規約をケバブケースに修正し、CIチェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,9 @@ on:
     branches:
       - main
       - develop
-    paths-ignore:
-      - 'doc/**'
-      - '*.md'
   pull_request:
     branches:
       - develop
-    paths-ignore:
-      - 'doc/**'
-      - '*.md'
 
 # 並列実行 + 重複起動防止
 concurrency:
@@ -64,6 +58,14 @@ jobs:
           TEST_DB_JDBC_URL: jdbc:mysql://localhost:3306/keruta_test
           TEST_DB_USERNAME: keruta
           TEST_DB_PASSWORD: keruta
+
+  # ドキュメント関連のチェック
+  doc-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check doc/ filename conventions
+        run: bash scripts/check-doc-filenames.sh
 
   # ktcl-front と kicl-web は並列実行
   ktcl-front:

--- a/doc/convention.md
+++ b/doc/convention.md
@@ -11,7 +11,7 @@
 
 ## ファイル命名規則
 
-- 小文字スネークケース（`snake_case`）
+- 小文字ケバブケース（`kebab-case`、ハイフン区切り）
 - 拡張子は `.md`
 - 例: `kicl-web.md`, `database.md`, `processing-flows.md`
 

--- a/scripts/check-doc-filenames.sh
+++ b/scripts/check-doc-filenames.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# doc/ ディレクトリ内のファイル命名規則（ケバブケース）をチェックするスクリプト
+
+set -euo pipefail
+
+# ケバブケースの正規表現: 小文字、数字、ハイフンのみ（連続するハイフンや末尾・先頭のハイフンは不可）
+# 例: kicl-web.md, database.md, processing-flows.md
+KEBAB_CASE_REGEX='^[a-z0-9]+(-[a-z0-9]+)*\.md$'
+
+DOC_DIR="doc"
+ERROR_COUNT=0
+
+echo "Checking doc/ filename conventions (kebab-case)..."
+echo ""
+
+if [ ! -d "$DOC_DIR" ]; then
+    echo "Error: $DOC_DIR directory not found."
+    exit 1
+fi
+
+# doc/ 配下の .md ファイルを再帰的にチェック
+while IFS= read -r -d '' file; do
+    # ファイル名のみを抽出（パスを除く）
+    filename=$(basename "$file")
+    
+    # README.md は標準ファイルのためチェックから除外
+    if [[ "$filename" == "README.md" ]]; then
+        echo "⚪ $file (excluded: standard filename)"
+        continue
+    fi
+    
+    # 正規表現にマッチしない場合はエラー
+    if [[ ! "$filename" =~ $KEBAB_CASE_REGEX ]]; then
+        echo "❌ $file"
+        echo "   Error: Filename '$filename' does not follow kebab-case convention."
+        echo "   Expected: lowercase letters, numbers, hyphens (e.g., kicl-web.md)"
+        ERROR_COUNT=$((ERROR_COUNT + 1))
+    else
+        echo "✅ $file"
+    fi
+done < <(find "$DOC_DIR" -type f -name "*.md" -print0 | sort -z)
+
+echo ""
+echo "----------------------------------------"
+
+if [ $ERROR_COUNT -eq 0 ]; then
+    echo "✅ All doc/ filenames follow kebab-case convention!"
+    exit 0
+else
+    echo "❌ Found $ERROR_COUNT filename(s) that violate the convention."
+    echo "Please rename files to follow kebab-case: lowercase with hyphens."
+    exit 1
+fi


### PR DESCRIPTION
# タイトル
docファイル名規約をケバブケースに修正し、CIチェックを追加

## 概要
ドキュメントファイル命名規則をスネークケースからケバブケース（ハイフン区切り）に変更し、その規約を検証する自動チェックスクリプトを追加しました。また、CIパイプラインにドキュメント関連のチェックを組み込みました。

## 背景・目的
従来の規約（スネークケース）と例示（kicl-web.md等のケバブケース）に不一致があったため、規約を実態に合わせて修正する必要がありました。また、規約を矯正する仕組みとして、ファイル名を自動検証するスクリプトとCIチェックを導入し、今後の遵守を担保します。

## 変更内容
- `doc/convention.md` のファイル命名規則を「小文字ケバブケース（kebab-case）」に修正
- `scripts/check-doc-filenames.sh` を新規作成
  - `doc/` 配下の `.md` ファイルがケバブケースに従っているか検証
  - `README.md` は標準ファイルとして除外
- `.github/workflows/ci.yml` を修正
  - `paths-ignore` を削除し、ドキュメント変更時もCIを実行するように変更
  - `doc-checks` ジョブを追加し、CI実行時に自動でファイル名チェックを実施

## 確認方法
1. ローカルでのチェック実行:
   ```bash
   bash scripts/check-doc-filenames.sh
   ```
2. CIパイプラインが正常に実行され、doc-checksジョブがパスすることを確認

## その他
- 既存の `doc/` 配下のファイルはすべてケバブケースに準拠しています（README.mdを除く）
- 今後 `doc/` に新規ファイルを追加する際は、自動的に命名規則がチェックされます