### PR TITLE
feat: kicpモジュールのJS出力設定を追加

### DIFF
--- a/kicp/kicp-domain/build.gradle.kts
+++ b/kicp/kicp-domain/build.gradle.kts
@@ -4,6 +4,17 @@ plugins {
     id("serialize")
 }
 kotlin {
+    js {
+        binaries.library()
+        generateTypeScriptDefinitions()
+        compilerOptions {
+            moduleKind = org.jetbrains.kotlin.gradle.dsl.JsModuleKind.MODULE_ES
+        }
+        compilations["main"].packageJson {
+            customField("type", "module")
+            customField("types", "keruta-kicp-kicp-domain.d.mts")
+        }
+    }
     sourceSets["commonMain"].dependencies {
         api(project(":kodel:api"))
     }

--- a/kicp/kicp-usecase/build.gradle.kts
+++ b/kicp/kicp-usecase/build.gradle.kts
@@ -4,6 +4,17 @@ plugins {
     id("serialize")
 }
 kotlin {
+    js {
+        binaries.library()
+        generateTypeScriptDefinitions()
+        compilerOptions {
+            moduleKind = org.jetbrains.kotlin.gradle.dsl.JsModuleKind.MODULE_ES
+        }
+        compilations["main"].packageJson {
+            customField("type", "module")
+            customField("types", "keruta-kicp-kicp-usecase.d.mts")
+        }
+    }
     sourceSets["commonMain"].dependencies {
         api(project(":kicp:kicp-domain"))
     }


### PR DESCRIPTION
# タイトル
kicpモジュールのJS出力設定を追加

## 概要
kicp-domainおよびkicp-usecaseモジュールにJSターゲットを追加し、ブラウザ環境で使用できるようにしました。

## 背景・目的
kicl-web（React Router v7 + Kotlin Multiplatform共有ロジック）からkicpクライアントを登録するには、kicpモジュールがJSライブラリとして出力されている必要があります。現在はJS出力設定がなかったため、ブラウザ環境でkicpの機能を使用できませんでした。

## 変更内容
- **kicp-domain/build.gradle.kts**: JSターゲットを追加
  - `binaries.library()`の設定
  - TypeScript定義ファイルの生成設定
  - ESモジュール形式の出力設定
- **kicp-usecase/build.gradle.kts**: JSターゲットを追加
  - 同様のJS出力設定

## 確認方法
1. `./gradlew :kicp:kicp-domain:jsBrowserProductionLibraryDistribution`を実行し、ビルドが成功することを確認
2. `./gradlew :kicp:kicp-usecase:jsBrowserProductionLibraryDistribution`を実行し、ビルドが成功することを確認
3. 各モジュールの`build/dist/js/productionLibrary/`に`.mjs`ファイルと`.d.mts`ファイルが生成されることを確認

## その他
- ソースコードの変更はありません
- 他のモジュールへの依存関係は変更していません
- 純粋なビルド設定の追加のみです