### PR TITLE
feat: kicl-usecaseにkicp-usecaseへの依存を追加

### DIFF
--- a/kicl/kicl-usecase/build.gradle.kts
+++ b/kicl/kicl-usecase/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
     }
     sourceSets["commonMain"].dependencies {
         api(project(":kicl:kicl-domain"))
+        api(project(":kicp:kicp-usecase"))
     }
     sourceSets["commonTest"].dependencies {
     }


### PR DESCRIPTION
# タイトル
kicl-usecaseにkicp-usecaseへの依存を追加

## 概要
kicl-usecaseモジュールにkicp-usecaseへの依存を追加し、共有ロジックからkicpの機能を呼び出せるようにしました。

## 背景・目的
kicl-webからkicpクライアントを登録するには、kicl-usecase層でkicpのユースケースを使用する必要があります。現在は依存関係がなかったため、kicpの機能を利用できませんでした。

## 変更内容
- `kicl/kicl-usecase/build.gradle.kts`に`api(project(":kicp:kicp-usecase"))`を追加
- 依存関係を追加したことで、kicl-usecaseからkicp-usecaseのクラスを参照可能に

## 確認方法
1. `./gradlew :kicl:kicl-usecase:compileKotlinJs`を実行し、コンパイルが成功することを確認
2. `./gradlew :kicl:kicl-usecase:jsBrowserProductionLibraryDistribution`を実行し、JS出力が成功することを確認

## その他
- ソースコードの変更はありません
- 依存関係の追加のみです