### PR TITLE
feat: kicl-web設定画面にkicp登録フォームを追加

### DIFF
--- a/kicl-web/app/routes/settings.tsx
+++ b/kicl-web/app/routes/settings.tsx
@@ -1,4 +1,5 @@
 import {Form, useActionData, useLoaderData} from 'react-router';
+import {useState} from 'react';
 import {type AppSettings, defaultSettings, SETTINGS_STORAGE_KEY} from '../types/settings';
 
 export async function clientLoader(): Promise<AppSettings> {
@@ -26,6 +27,68 @@ export function HydrateFallback() {
 export default function Settings() {
     const settings = useLoaderData() as AppSettings;
     const actionData = useActionData() as { saved: boolean } | undefined;
+    const [registerStatus, setRegisterStatus] = useState<{success: boolean; message: string} | null>(null);
+    const [isRegistering, setIsRegistering] = useState(false);
+
+    const handleKicpRegister = async () => {
+        setIsRegistering(true);
+        setRegisterStatus(null);
+
+        try {
+            const form = document.querySelector('form[method="post"]')?.closest('div')?.querySelector('section:last-of-type');
+            const oidcTokenInput = form?.querySelector('input[name="oidcToken"]') as HTMLInputElement;
+            const providerTokenInput = form?.querySelector('input[name="providerToken"]') as HTMLInputElement;
+            const registerTokenInput = form?.querySelector('input[name="registerToken"]') as HTMLInputElement;
+
+            const oidcToken = oidcTokenInput?.value || '';
+            const providerToken = providerTokenInput?.value || '';
+            const registerToken = registerTokenInput?.value || '';
+
+            if (!oidcToken || !providerToken || !registerToken) {
+                setRegisterStatus({success: false, message: 'すべてのトークンを入力してください。'});
+                return;
+            }
+
+            if (!settings.ktseUrl) {
+                setRegisterStatus({success: false, message: 'タスクサーバーURLが設定されていません。'});
+                return;
+            }
+
+            const registerUrl = `${settings.ktseUrl}/api/kicp/register`;
+
+            console.log('kicpクライアント登録リクエスト送信:', {
+                url: registerUrl,
+                oidcToken: oidcToken.substring(0, 20) + '...',
+                hasProviderToken: !!providerToken,
+                hasRegisterToken: !!registerToken,
+            });
+
+            const response = await fetch(registerUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    oidcToken,
+                    providerToken,
+                    registerToken,
+                }),
+            });
+
+            if (response.ok) {
+                const data = await response.json().catch(() => ({ message: 'レスポンスの解析に失敗しました' }));
+                setRegisterStatus({success: true, message: `登録成功: ${JSON.stringify(data)}`});
+            } else {
+                const errorText = await response.text().catch(() => response.statusText);
+                setRegisterStatus({success: false, message: `登録失敗: ${response.status} ${errorText}`});
+            }
+        } catch (error) {
+            console.error('kicp登録エラー:', error);
+            setRegisterStatus({success: false, message: `エラー: ${error instanceof Error ? error.message : String(error)}`});
+        } finally {
+            setIsRegistering(false);
+        }
+    };
 
     return (
         <div className="max-w-2xl mx-auto p-8">
@@ -84,6 +147,57 @@ export default function Settings() {
                     保存
                 </button>
             </Form>
+
+            {/* kicpクライアント登録セクション */}
+            <section className="mt-12 pt-8 border-t border-gray-200">
+                <h2 className="text-base font-semibold text-gray-700 mb-4">kicpクライアント登録</h2>
+                <p className="text-sm text-gray-600 mb-4">
+                    kicpクライアントを登録して、クロスドメイン認証を有効化します。
+                </p>
+
+                {registerStatus && (
+                    <div className={`mb-4 rounded border px-4 py-3 text-sm ${
+                        registerStatus.success 
+                            ? 'bg-green-50 border-green-200 text-green-700' 
+                            : 'bg-red-50 border-red-200 text-red-700'
+                    }`}>
+                        {registerStatus.message}
+                    </div>
+                )}
+
+                <div className="space-y-4">
+                    <Field
+                        label="OIDCトークン"
+                        name="oidcToken"
+                        defaultValue={localStorage.getItem('oidc_token') || ''}
+                        placeholder="OIDCトークンを入力"
+                        type="text"
+                    />
+                    <Field
+                        label="プロバイダートークン"
+                        name="providerToken"
+                        defaultValue={localStorage.getItem('provider_token') || ''}
+                        placeholder="プロバイダートークンを入力"
+                        type="text"
+                    />
+                    <Field
+                        label="登録トークン"
+                        name="registerToken"
+                        defaultValue={localStorage.getItem('register_token') || ''}
+                        placeholder="登録トークンを入力"
+                        type="text"
+                    />
+                </div>
+
+                <button
+                    type="button"
+                    onClick={handleKicpRegister}
+                    disabled={isRegistering}
+                    className="mt-4 rounded bg-green-600 px-5 py-2 text-sm font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50"
+                >
+                    {isRegistering ? '登録中...' : 'kicpクライアントを登録'}
+                </button>
+            </section>
         </div>
     );
 }
@@ -93,18 +207,20 @@ function Field({
     name,
     defaultValue,
     placeholder,
+    type = 'text',
 }: {
     label: string;
     name: string;
     defaultValue: string;
     placeholder: string;
+    type?: string;
 }) {
     return (
         <label className="block">
             <span className="block text-sm font-medium text-gray-600 mb-1">{label}</span>
             <input
                 name={name}
-                type="url"
+                type={type}
                 defaultValue={defaultValue}
                 placeholder={placeholder}
                 className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"

--- a/kicl-web/vite.config.ts
+++ b/kicl-web/vite.config.ts
@@ -10,16 +10,28 @@ export default defineConfig({
         reactRouter(),
         tsconfigPaths()
     ],
+    resolve: {
+        preserveSymlinks: true,
+    },
     optimizeDeps: {
         include: [
             "keruta-kicl-kicl-domain",
             "keruta-kicl-kicl-usecase",
+            "keruta-kicp-kicp-domain",
+            "keruta-kicp-kicp-usecase",
         ],
     },
     ssr: {
         external: [
             "keruta-kicl-kicl-domain",
             "keruta-kicl-kicl-usecase",
+            "keruta-kicp-kicp-domain",
+            "keruta-kicp-kicp-usecase",
         ],
+    },
+    build: {
+        commonjsOptions: {
+            transformMixedEsModules: true,
+        },
     },
 })


### PR DESCRIPTION
# タイトル
kicl-web設定画面にkicp登録フォームを追加

## 概要
設定画面にkicpクライアント登録用のフォームを追加し、ユーザーがトークンを入力して登録リクエストを送信できるようにしました。

## 背景・目的
kicpクライアント登録機能をユーザーが利用するには、UIが必要です。設定画面にフォームを追加することで、実際の登録フローをテストできるようにします。

## 変更内容
- `app/routes/settings.tsx`: kicp登録セクションを追加（トークン入力欄・登録ボタン）
- `vite.config.ts`: kicpモジュールの依存関係を追加
- `package.json`: kicp JSライブラリへの参照を追加

## 確認方法
1. `cd kicl-web && npm run dev`で開発サーバーを起動
2. `http://localhost:5173/settings`にアクセス
3. 「kicpクライアント登録」セクションが表示されることを確認
4. トークンを入力して「kicpクライアントを登録」ボタンをクリックし、リクエストが送信されることを確認

## その他
- 現在はモック的な実装で、実際のバックエンドエンドポイントを呼び出すようになっています
- エラーハンドリングとローディング状態の表示を追加