### PR TITLE
feat: ktseにkicp登録用エンドポイントを追加

### DIFF
--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
@@ -1,6 +1,9 @@
 package net.kigawa.keruta.ktse
 
+import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import net.kigawa.keruta.ktse.websocket.KtorWebsocketModule
 import net.kigawa.kodel.api.log.LogLevel
@@ -34,6 +37,40 @@ class KerutaTaskServer {
         val ws = KtorWebsocketModule(this@module,this@KerutaTaskServer)
         routing {
             ws.websocketModule(this@routing)
+
+            // kicpクライアント登録エンドポイント
+            post("/api/kicp/register") {
+                try {
+                    val params = call.receive<Map<String, String>>()
+                    val oidcToken = params["oidcToken"] ?: ""
+                    val providerToken = params["providerToken"] ?: ""
+                    val registerToken = params["registerToken"] ?: ""
+
+                    // TODO: 実際のkicp登録ロジックを実装する
+                    // 現在はモックレスポンスを返す
+                    val logMsg = "kicp登録リクエスト受信: oidcToken=" + oidcToken.take(20) + "..."
+                    call.application.environment.log.info(logMsg)
+
+                    call.respond(
+                        HttpStatusCode.OK,
+                        mapOf(
+                            "success" to true,
+                            "message" to "kicpクライアント登録リクエストを受け付けました（モック）",
+                            "received" to mapOf(
+                                "hasOidcToken" to oidcToken.isNotEmpty(),
+                                "hasProviderToken" to providerToken.isNotEmpty(),
+                                "hasRegisterToken" to registerToken.isNotEmpty()
+                            )
+                        )
+                    )
+                } catch (e: Exception) {
+                    call.application.environment.log.error("kicp登録エラー: " + (e.message ?: ""))
+                    call.respond(
+                        HttpStatusCode.InternalServerError,
+                        mapOf("success" to false, "message" to ("エラー: " + (e.message ?: "")))
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# タイトル
ktseにkicp登録用エンドポイントを追加

## 概要
ktseタスクサーバーにkicpクライアント登録用のRESTエンドポイント（/api/kicp/register）を追加しました。

## 背景・目的
kicl-webから送信された登録リクエストを受け付けるには、バックエンド側にエンドポイントが必要です。まずはモック実装でリクエストを受け付けるところまで実装します。

## 変更内容
- `KerutaTaskServer.kt`: `routing { }`内に`post("/api/kicp/register")`エンドポイントを追加
- 現在はモックレスポンスを返す実装（実際のkicp登録ロジックは今後の課題）

## 確認方法
1. `./gradlew :ktse:run`でktseを起動
2. `curl -X POST http://localhost:8080/api/kicp/register -H "Content-Type: application/json" -d '{"oidcToken":"test","providerToken":"test","registerToken":"test"}'`を実行
3. JSONレスポンスが返ってくることを確認

## その他
- 実際のkicp登録ロジック（署名検証・ID保存等）は今後のPRで実装予定
- 現在はモックのため、常に成功レスポンスを返します