### PR TITLE
feat: ktseのkicp登録エンドポイントを実装に変更

### DIFF
--- a/ktse/build.gradle.kts
+++ b/ktse/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.shadowJar {
 
 dependencies {
     implementation(project(":ktse-sdk"))
+    implementation(project(":kicp:kicp-usecase"))
     // https://mvnrepository.com/artifact/com.auth0/java-jwt
     implementation("com.auth0:java-jwt:${Version.JAVA_JWT}")
     implementation("com.auth0:jwks-rsa:${Version.JWKS_RSA}")

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
@@ -2,9 +2,13 @@ package net.kigawa.keruta.ktse
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.serialization.kotlinx.json.*
+import net.kigawa.keruta.ktse.kicp.RegisterRequest
+import net.kigawa.keruta.ktse.kicp.RegisterUseCaseFactory
 import net.kigawa.keruta.ktse.websocket.KtorWebsocketModule
 import net.kigawa.kodel.api.log.LogLevel
 import net.kigawa.kodel.api.log.LoggerFactory
@@ -34,6 +38,9 @@ class KerutaTaskServer {
 
     @Suppress("unused")
     fun Application.module() {
+        install(ContentNegotiation) {
+            json()
+        }
         val ws = KtorWebsocketModule(this@module,this@KerutaTaskServer)
         routing {
             ws.websocketModule(this@routing)
@@ -41,34 +48,45 @@ class KerutaTaskServer {
             // kicpクライアント登録エンドポイント
             post("/api/kicp/register") {
                 try {
-                    val params = call.receive<Map<String, String>>()
-                    val oidcToken = params["oidcToken"] ?: ""
-                    val providerToken = params["providerToken"] ?: ""
-                    val registerToken = params["registerToken"] ?: ""
-
-                    // TODO: 実際のkicp登録ロジックを実装する
-                    // 現在はモックレスポンスを返す
-                    val logMsg = "kicp登録リクエスト受信: oidcToken=" + oidcToken.take(20) + "..."
-                    call.application.environment.log.info(logMsg)
-
-                    call.respond(
-                        HttpStatusCode.OK,
-                        mapOf(
-                            "success" to true,
-                            "message" to "kicpクライアント登録リクエストを受け付けました（モック）",
-                            "received" to mapOf(
-                                "hasOidcToken" to oidcToken.isNotEmpty(),
-                                "hasProviderToken" to providerToken.isNotEmpty(),
-                                "hasRegisterToken" to registerToken.isNotEmpty()
-                            )
-                        )
+                    val request = call.receive<RegisterRequest>()
+                    
+                    val registerUseCase = RegisterUseCaseFactory.create()
+                    val input = net.kigawa.keruta.kicp.usecase.register.RegisterInput(
+                        oidcToken = net.kigawa.keruta.kicp.domain.token.OidcToken(request.oidcToken),
+                        oidcJwksUrl = net.kigawa.keruta.kicp.domain.jwks.JwksUrl(request.oidcJwksUrl),
+                        providerToken = net.kigawa.keruta.kicp.domain.token.ProviderToken(request.providerToken),
+                        providerJwksUrl = net.kigawa.keruta.kicp.domain.jwks.JwksUrl(request.providerJwksUrl),
+                        registerToken = net.kigawa.keruta.kicp.domain.token.RegisterToken(request.registerToken),
                     )
+                    
+                     when (val result = registerUseCase.register(input)) {
+                         is net.kigawa.kodel.api.err.Res.Ok -> {
+                             call.respond(
+                                 HttpStatusCode.OK,
+                                 mapOf(
+                                     "success" to true,
+                                     "message" to "kicpクライアント登録が完了しました",
+                                     "identityId" to result.value.value
+                                 )
+                             )
+                         }
+                         is net.kigawa.kodel.api.err.Res.Err -> {
+                             call.application.environment.log.error("kicp登録失敗: ${result.err.message}")
+                             call.respond(
+                                 HttpStatusCode.BadRequest,
+                                 mapOf(
+                                     "success" to false,
+                                     "message" to "登録に失敗しました: ${result.err.message}"
+                                 )
+                             )
+                         }
+                     }
                 } catch (e: Exception) {
                     call.application.environment.log.error("kicp登録エラー: " + (e.message ?: ""))
-                    call.respond(
-                        HttpStatusCode.InternalServerError,
-                        mapOf("success" to false, "message" to ("エラー: " + (e.message ?: "")))
-                    )
+                     call.respond(
+                         HttpStatusCode.InternalServerError,
+                         mapOf("success" to false, "message" to ("エラー: " + (e.message ?: "")))
+                     )
                 }
             }
         }

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/JwksRepositoryImpl.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/JwksRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package net.kigawa.keruta.ktse.kicp
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import net.kigawa.keruta.kicp.domain.err.JwksFetchErr
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.jwks.JwksUrl
+import net.kigawa.keruta.kicp.domain.repo.JwksRepository
+import net.kigawa.kodel.api.err.Res
+
+/**
+ * JWKSをHTTPで取得する実装
+ */
+class JwksRepositoryImpl(
+    private val httpClient: HttpClient,
+) : JwksRepository {
+    override suspend fun get(url: JwksUrl): Res<Jwks, KicpErr> {
+        return try {
+            val jwks: Jwks = httpClient.get(url.value).body()
+            Res.Ok(jwks)
+        } catch (e: Exception) {
+            Res.Err(JwksFetchErr(url.value, e))
+        }
+    }
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/JwtVerifierImpl.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/JwtVerifierImpl.kt
@@ -1,0 +1,73 @@
+package net.kigawa.keruta.ktse.kicp
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.JWTVerifier as Auth0JWTVerifier
+import net.kigawa.keruta.kicp.domain.claims.TokenClaims
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.TokenVerificationErr
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.jwks.JwkKey
+import net.kigawa.keruta.kicp.domain.repo.JwtVerifier
+import net.kigawa.kodel.api.err.Res
+import java.security.KeyFactory
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.Base64
+
+/**
+ * Auth0のjava-jwtライブラリを使用してJWTを検証する実装
+ */
+class JwtVerifierImpl : JwtVerifier {
+    override suspend fun verify(rawToken: String, jwks: Jwks): Res<TokenClaims, KicpErr> {
+        return try {
+            // JWKSから適切なキーを選択（kidでマッチング）
+            val decodedJwt = JWT.decode(rawToken)
+            val kid = decodedJwt.keyId
+            
+            val jwkKey = jwks.keys.find { it.kid == kid }
+                ?: return Res.Err(TokenVerificationErr("適切なJWKキーが見つかりません: kid=$kid"))
+            
+            // RSA公開鍵を構築
+            val publicKey = buildRsaPublicKey(jwkKey)
+            
+            // アルゴリズムを選択
+            val algorithm = when (jwkKey.alg) {
+                "RS256" -> Algorithm.RSA256(publicKey, null)
+                "RS384" -> Algorithm.RSA384(publicKey, null)
+                "RS512" -> Algorithm.RSA512(publicKey, null)
+                else -> return Res.Err(TokenVerificationErr("サポートされていないアルゴリズムです: ${jwkKey.alg}"))
+            }
+            
+            // JWTを検証
+            val verifier: Auth0JWTVerifier = JWT.require(algorithm)
+                .build()
+            
+            val verifiedJwt = verifier.verify(rawToken)
+            
+            // クレームを抽出
+            val claims = TokenClaims(
+                issuer = verifiedJwt.issuer ?: "",
+                subject = verifiedJwt.subject ?: "",
+                audience = verifiedJwt.audience ?: emptyList(),
+            )
+            
+            Res.Ok(claims)
+        } catch (e: Exception) {
+            Res.Err(TokenVerificationErr("JWTの検証に失敗しました: ${e.message}", e))
+        }
+    }
+    
+    private fun buildRsaPublicKey(jwkKey: JwkKey): RSAPublicKey {
+        val keyFactory = KeyFactory.getInstance("RSA")
+        
+        val nBytes = Base64.getUrlDecoder().decode(jwkKey.n)
+        val eBytes = Base64.getUrlDecoder().decode(jwkKey.e)
+        
+        val n = java.math.BigInteger(1, nBytes)
+        val e = java.math.BigInteger(1, eBytes)
+        
+        val spec = RSAPublicKeySpec(n, e)
+        return keyFactory.generatePublic(spec) as RSAPublicKey
+    }
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/PeerServerClientImpl.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/PeerServerClientImpl.kt
@@ -1,0 +1,48 @@
+package net.kigawa.keruta.ktse.kicp
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.PeerVerificationErr
+import net.kigawa.keruta.kicp.domain.identity.RegisterId
+import net.kigawa.keruta.kicp.domain.repo.PeerServerClient
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.kodel.api.err.Res
+
+/**
+ * 対端サーバー（idServerA）に登録トークンを検証する実装
+ * 実際の環境では、idServerAのAPIエンドポイントを呼び出す
+ */
+class PeerServerClientImpl(
+    private val httpClient: HttpClient,
+    private val peerServerBaseUrl: String,
+) : PeerServerClient {
+    override suspend fun verifyRegister(registerId: RegisterId, registerToken: RegisterToken): Res<Unit, KicpErr> {
+        return try {
+            // idServerAの検証エンドポイントを呼び出す
+            // 現在はモックとして常に成功を返す
+            // TODO: 実際のidServerAのエンドポイントを実装したら、そこにリクエストを送る
+            
+            // モック実装: 常に成功
+            Res.Ok(Unit)
+            
+            // 実際の実装例:
+            // val response: HttpResponse = httpClient.post("$peerServerBaseUrl/api/kicp/verify-register") {
+            //     contentType(ContentType.Application.Json)
+            //     setBody(mapOf(
+            //         "registerId" to registerId.value,
+            //         "registerToken" to registerToken.value
+            //     ))
+            // }
+            // 
+            // if (response.status == HttpStatusCode.OK) {
+            //     Res.Ok(Unit)
+            // } else {
+            //     Res.Err(PeerVerificationErr("登録トークンの検証に失敗しました: ${response.status}"))
+            // }
+        } catch (e: Exception) {
+            Res.Err(PeerVerificationErr("対端サーバーとの通信に失敗しました: ${e.message}", e))
+        }
+    }
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/RegisterRequest.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/RegisterRequest.kt
@@ -1,0 +1,15 @@
+package net.kigawa.keruta.ktse.kicp
+
+import kotlinx.serialization.Serializable
+
+/**
+ * kicp登録リクエストのボディ
+ */
+@Serializable
+data class RegisterRequest(
+    val oidcToken: String,
+    val providerToken: String,
+    val registerToken: String,
+    val oidcJwksUrl: String,
+    val providerJwksUrl: String,
+)

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/RegisterUseCaseFactory.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/RegisterUseCaseFactory.kt
@@ -1,0 +1,36 @@
+package net.kigawa.keruta.ktse.kicp
+
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCase
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCaseImpl
+
+/**
+ * RegisterUseCaseのFactoryクラス（DIパターンに従って手動で依存性を注入）
+ */
+object RegisterUseCaseFactory {
+    /**
+     * RegisterUseCaseのインスタンスを作成する
+     * 
+     * @param peerServerBaseUrl 対端サーバー（idServerA）のベースURL
+     * @return RegisterUseCaseのインスタンス
+     */
+    fun create(peerServerBaseUrl: String = "http://localhost:8080"): RegisterUseCase {
+        val httpClient = HttpClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        
+        val jwksRepository = JwksRepositoryImpl(httpClient)
+        val jwtVerifier = JwtVerifierImpl()
+        val peerServerClient = PeerServerClientImpl(httpClient, peerServerBaseUrl)
+        
+        return RegisterUseCaseImpl(
+            jwksRepository = jwksRepository,
+            jwtVerifier = jwtVerifier,
+            peerServerClient = peerServerClient,
+        )
+    }
+}


### PR DESCRIPTION
# kicp登録エンドポイントの実装化

## 概要
ktseモジュールのkicpクライアント登録エンドポイント（`POST /api/kicp/register`）のモック実装を、実際のビジネスロジックを使用した実装に変更しました。

## 背景・目的
これまでモックとして実装されていたkicp登録エンドポイントを、kicp-usecaseモジュールで定義された`RegisterUseCase`を使用して実際の処理を行うようにするため。これにより、JWT検証、JWKS取得、対端サーバーとの検証などの本格的な登録フローが利用可能になります。

## 変更内容
- **ktse/build.gradle.kts**: kicp-usecaseモジュールへの依存を追加
- **ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt**:
  - ContentNegotiationプラグインの追加
  - モックから実際の`RegisterUseCase`を使用するように変更
  - `RegisterRequest`データクラスを使用した型安全なリクエスト処理
- **新規ファイル**（ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/）:
  - `JwksRepositoryImpl.kt`: JWKSをHTTPで取得する実装
  - `JwtVerifierImpl.kt`: Auth0のjava-jwtライブラリを使用したJWT検証
  - `PeerServerClientImpl.kt`: 対端サーバー（idServerA）との通信実装（現時点ではモック）
  - `RegisterRequest.kt`: 登録リクエスト用データクラス
  - `RegisterUseCaseFactory.kt`: DIパターンに従ったファクトリクラス

## 確認方法
1. `./gradlew :ktse:build` でビルドが成功することを確認
2. ktseサーバーを起動し、`POST /api/kicp/register` に適切なリクエストを送信してレスポンスを確認
3. 各エラーケース（無効なJWT、期限切れトークン等）の動作確認

## その他
- `PeerServerClientImpl`は現在モック実装（常に成功を返す）となっています。実際のidServerAとの連携が必要になった際は、TODOコメントの部分を実装してください。
- JWT検証ではRS256/384/512アルゴリズムに対応しています。
- kicpモジュールの`Res<T, E>`パターンを使用して、例外を使わない型安全なエラーハンドリングを実現しています。