### PR TITLE
feat(ktse): PeerServerClientImplの本実装

### DIFF
--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
@@ -9,6 +9,11 @@ import io.ktor.server.routing.*
 import io.ktor.serialization.kotlinx.json.*
 import net.kigawa.keruta.ktse.kicp.RegisterRequest
 import net.kigawa.keruta.ktse.kicp.RegisterUseCaseFactory
+import net.kigawa.keruta.ktse.kicp.VerifyRegisterRequest
+import net.kigawa.keruta.ktse.kicp.VerifyRegisterTokenUseCaseFactory
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterInput
+import net.kigawa.keruta.kicp.domain.identity.RegisterId
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
 import net.kigawa.keruta.ktse.websocket.KtorWebsocketModule
 import net.kigawa.kodel.api.log.LogLevel
 import net.kigawa.kodel.api.log.LoggerFactory
@@ -87,6 +92,49 @@ class KerutaTaskServer {
                          HttpStatusCode.InternalServerError,
                          mapOf("success" to false, "message" to ("エラー: " + (e.message ?: "")))
                      )
+                }
+            }
+            
+            // kicp登録トークン検証エンドポイント（idServerA側）
+            post("/api/kicp/verify-register") {
+                try {
+                    val request = call.receive<VerifyRegisterRequest>()
+                    
+                    val verifyUseCase = VerifyRegisterTokenUseCaseFactory.create()
+                    val input = VerifyRegisterInput(
+                        registerId = RegisterId(request.registerId),
+                        registerToken = RegisterToken(request.registerToken),
+                        currentTimeMs = System.currentTimeMillis(),
+                    )
+                    
+                    when (val result = verifyUseCase.verify(input)) {
+                        is net.kigawa.kodel.api.err.Res.Ok -> {
+                            call.respond(
+                                HttpStatusCode.OK,
+                                mapOf(
+                                    "success" to true,
+                                    "message" to "登録トークンの検証に成功しました",
+                                    "identityId" to result.value.value
+                                )
+                            )
+                        }
+                        is net.kigawa.kodel.api.err.Res.Err -> {
+                            call.application.environment.log.error("kicp検証失敗: ${result.err.message}")
+                            call.respond(
+                                HttpStatusCode.BadRequest,
+                                mapOf(
+                                    "success" to false,
+                                    "message" to "検証に失敗しました: ${result.err.message}"
+                                )
+                            )
+                        }
+                    }
+                } catch (e: Exception) {
+                    call.application.environment.log.error("kicp検証エラー: " + (e.message ?: ""))
+                    call.respond(
+                        HttpStatusCode.InternalServerError,
+                        mapOf("success" to false, "message" to ("エラー: " + (e.message ?: "")))
+                    )
                 }
             }
         }

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/InMemoryRegisterTokenRepository.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/InMemoryRegisterTokenRepository.kt
@@ -1,0 +1,29 @@
+package net.kigawa.keruta.ktse.kicp
+
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRepository
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRecord
+import net.kigawa.kodel.api.err.Res
+
+/**
+ * インメモリで登録トークンを管理するRepository実装
+ * 本番環境では適切な永続化ストレージを使用すること
+ */
+class InMemoryRegisterTokenRepository : RegisterTokenRepository {
+    private val storage = mutableMapOf<RegisterToken, RegisterTokenRecord>()
+
+    override suspend fun save(record: RegisterTokenRecord): Res<Unit, KicpErr> {
+        storage[record.token] = record
+        return Res.Ok(Unit)
+    }
+
+    override suspend fun find(token: RegisterToken): Res<RegisterTokenRecord?, KicpErr> {
+        return Res.Ok(storage[token])
+    }
+
+    override suspend fun delete(token: RegisterToken): Res<Unit, KicpErr> {
+        storage.remove(token)
+        return Res.Ok(Unit)
+    }
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/PeerServerClientImpl.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/PeerServerClientImpl.kt
@@ -2,6 +2,7 @@ package net.kigawa.keruta.ktse.kicp
 
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.HttpResponse
 import io.ktor.http.*
 import net.kigawa.keruta.kicp.domain.err.KicpErr
 import net.kigawa.keruta.kicp.domain.err.PeerVerificationErr
@@ -21,26 +22,21 @@ class PeerServerClientImpl(
     override suspend fun verifyRegister(registerId: RegisterId, registerToken: RegisterToken): Res<Unit, KicpErr> {
         return try {
             // idServerAの検証エンドポイントを呼び出す
-            // 現在はモックとして常に成功を返す
-            // TODO: 実際のidServerAのエンドポイントを実装したら、そこにリクエストを送る
+            val response: HttpResponse = httpClient.post("$peerServerBaseUrl/api/kicp/verify-register") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    mapOf(
+                        "registerId" to registerId.value,
+                        "registerToken" to registerToken.value
+                    )
+                )
+            }
             
-            // モック実装: 常に成功
-            Res.Ok(Unit)
-            
-            // 実際の実装例:
-            // val response: HttpResponse = httpClient.post("$peerServerBaseUrl/api/kicp/verify-register") {
-            //     contentType(ContentType.Application.Json)
-            //     setBody(mapOf(
-            //         "registerId" to registerId.value,
-            //         "registerToken" to registerToken.value
-            //     ))
-            // }
-            // 
-            // if (response.status == HttpStatusCode.OK) {
-            //     Res.Ok(Unit)
-            // } else {
-            //     Res.Err(PeerVerificationErr("登録トークンの検証に失敗しました: ${response.status}"))
-            // }
+            if (response.status == HttpStatusCode.OK) {
+                Res.Ok(Unit)
+            } else {
+                Res.Err(PeerVerificationErr("登録トークンの検証に失敗しました: ${response.status}"))
+            }
         } catch (e: Exception) {
             Res.Err(PeerVerificationErr("対端サーバーとの通信に失敗しました: ${e.message}", e))
         }

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/VerifyRegisterRequest.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/VerifyRegisterRequest.kt
@@ -1,0 +1,9 @@
+package net.kigawa.keruta.ktse.kicp
+
+/**
+ * 登録トークン検証リクエスト
+ */
+data class VerifyRegisterRequest(
+    val registerId: String,
+    val registerToken: String
+)

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/VerifyRegisterTokenUseCaseFactory.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/kicp/VerifyRegisterTokenUseCaseFactory.kt
@@ -1,0 +1,28 @@
+package net.kigawa.keruta.ktse.kicp
+
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterTokenUseCase
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterTokenUseCaseImpl
+
+/**
+ * VerifyRegisterTokenUseCaseのFactoryクラス
+ * インメモリリポジトリをシングルトンとして管理し、トークンの保存と検証で共有する
+ */
+object VerifyRegisterTokenUseCaseFactory {
+    private val tokenRepository = InMemoryRegisterTokenRepository()
+    
+    /**
+     * VerifyRegisterTokenUseCaseのインスタンスを作成する
+     * 
+     * @return VerifyRegisterTokenUseCaseのインスタンス
+     */
+    fun create(): VerifyRegisterTokenUseCase {
+        return VerifyRegisterTokenUseCaseImpl(
+            tokenRepository = tokenRepository,
+        )
+    }
+    
+    /**
+     * トークンを保存するためのリポジトリを取得する（GetRegisterTokenUseCase用）
+     */
+    fun getTokenRepository(): InMemoryRegisterTokenRepository = tokenRepository
+}


### PR DESCRIPTION
# タイトル
feat(ktse): PeerServerClientImplの本実装

## 概要
PeerServerClientImplをモック実装から実際のHTTPリクエストを送信する本実装に変更し、idServerA側の検証エンドポイントを実装しました。

## 背景・目的
kicp（Kigawa Identity Cross-domain Protocol）において、idServerBからidServerAへの登録トークン検証フローを実現するため、PeerServerClientImplの本実装が必要でした。また、idServerA側で検証リクエストを受け付けるエンドポイントも実装する必要がありました。

## 変更内容
- `PeerServerClientImpl.kt`: モックから実際のHTTPリクエスト送信に変更（idServerAの`/api/kicp/verify-register`エンドポイントにPOSTリクエスト）
- `KerutaTaskServer.kt`: idServerA側の`/api/kicp/verify-register`エンドポイントを追加
- `InMemoryRegisterTokenRepository.kt`: インメモリでトークンを管理するRepository実装を新規追加
- `VerifyRegisterRequest.kt`: 検証リクエスト用データクラスを新規追加
- `VerifyRegisterTokenUseCaseFactory.kt`: 検証用UseCaseを生成するFactoryクラスを新規追加

## 確認方法
1. ktseモジュールを起動: `./gradlew :ktse:run`
2. idServerAとして`/api/kicp/verify-register`エンドポイントが応答することを確認
3. PeerServerClientImplが実際のHTTPリクエストを送信することを確認（ログ等で確認）

## その他
- 現在の`InMemoryRegisterTokenRepository`はインメモリ実装のため、本番環境では適切な永続化ストレージ（DB等）を使用するよう修正が必要です
- トークン発行用のエンドポイント（`/api/kicp/get-register-token`等）は別途実装が必要です