### PR TITLE
feat: RegisterTokenRepositoryのDB永続化実装を追加

### DIFF
--- a/ktse/build.gradle.kts
+++ b/ktse/build.gradle.kts
@@ -35,6 +35,7 @@ tasks.shadowJar {
 dependencies {
     implementation(project(":ktse-sdk"))
     implementation(project(":kicp:kicp-usecase"))
+    implementation(project(":kicp:kicp-domain"))
     // https://mvnrepository.com/artifact/com.auth0/java-jwt
     implementation("com.auth0:java-jwt:${Version.JAVA_JWT}")
     implementation("com.auth0:jwks-rsa:${Version.JWKS_RSA}")

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/persist/db/table/KicpRegisterTokenTable.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/persist/db/table/KicpRegisterTokenTable.kt
@@ -1,0 +1,10 @@
+package net.kigawa.keruta.ktse.persist.db.table
+
+import org.jetbrains.exposed.v1.core.Table
+
+object KicpRegisterTokenTable : Table("kicp_register_token") {
+    val token = varchar("token", 255)
+    val creatorIdentityId = varchar("creator_identity_id", 512)
+    val expiresAtEpochMs = long("expires_at_epoch_ms")
+    override val primaryKey = PrimaryKey(token)
+}

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/persist/kicp/ExposedRegisterTokenRepository.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/persist/kicp/ExposedRegisterTokenRepository.kt
@@ -1,0 +1,58 @@
+package net.kigawa.keruta.ktse.persist.kicp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.identity.IdentityId
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRecord
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRepository
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.keruta.ktse.persist.db.DbPersister
+import net.kigawa.keruta.ktse.persist.db.table.KicpRegisterTokenTable
+import net.kigawa.kodel.api.err.Res
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+@Suppress("DEPRECATION")
+class ExposedRegisterTokenRepository(
+    private val dbPersister: DbPersister,
+) : RegisterTokenRepository {
+
+    override suspend fun save(record: RegisterTokenRecord): Res<Unit, KicpErr> = withContext(Dispatchers.IO) {
+        transaction(dbPersister.db) {
+            KicpRegisterTokenTable.insert {
+                it[token] = record.token.value
+                it[creatorIdentityId] = record.creatorIdentityId.value
+                it[expiresAtEpochMs] = record.expiresAtEpochMs
+            }
+        }
+        Res.Ok(Unit)
+    }
+
+    override suspend fun find(token: RegisterToken): Res<RegisterTokenRecord?, KicpErr> = withContext(Dispatchers.IO) {
+        val row = transaction(dbPersister.db) {
+            KicpRegisterTokenTable.selectAll()
+                .where { KicpRegisterTokenTable.token eq token.value }
+                .singleOrNull()
+        }
+        Res.Ok(
+            row?.let {
+                RegisterTokenRecord(
+                    token = RegisterToken(it[KicpRegisterTokenTable.token]),
+                    creatorIdentityId = IdentityId(it[KicpRegisterTokenTable.creatorIdentityId]),
+                    expiresAtEpochMs = it[KicpRegisterTokenTable.expiresAtEpochMs],
+                )
+            }
+        )
+    }
+
+    override suspend fun delete(token: RegisterToken): Res<Unit, KicpErr> = withContext(Dispatchers.IO) {
+        transaction(dbPersister.db) {
+            KicpRegisterTokenTable.deleteWhere { KicpRegisterTokenTable.token eq token.value }
+        }
+        Res.Ok(Unit)
+    }
+}

--- a/ktse/src/main/resources/db/callback/V14__kicp_register_token.sql
+++ b/ktse/src/main/resources/db/callback/V14__kicp_register_token.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS kicp_register_token
+(
+    token               VARCHAR(255) NOT NULL,
+    creator_identity_id VARCHAR(512) NOT NULL,
+    expires_at_epoch_ms BIGINT       NOT NULL,
+    PRIMARY KEY (token)
+);


### PR DESCRIPTION
## 概要

- `RegisterTokenRepository`（`kicp-domain`）の Exposed + Flyway を使った DB バック実装を `ktse` モジュールに追加
- モック/インメモリ実装に代わり、本番環境での永続化に対応

## 変更内容

- `ktse/build.gradle.kts`: `kicp-domain` 依存を追加
- `V14__kicp_register_token.sql`: `kicp_register_token` テーブルの Flyway マイグレーション
- `KicpRegisterTokenTable.kt`: Exposed テーブル定義（token/creator_identity_id/expires_at_epoch_ms）
- `ExposedRegisterTokenRepository.kt`: `RegisterTokenRepository` の JVM 実装（`withContext(Dispatchers.IO)` + Exposed トランザクション）

## テスト計画

- [ ] `./gradlew :ktse:compileKotlin` でビルドが通ることを確認
- [ ] `./gradlew ktlintCheck` でリントが通ることを確認
- [ ] DB マイグレーション（V14）が既存の V13 の後に正しく適用されることを確認
- [ ] `ExposedRegisterTokenRepository` の save/find/delete が正しく動作することを確認（統合テスト）

## 残課題

- `KerutaTaskServer.kt` のモック KICP エンドポイントを実際のユースケース（`GetRegisterTokenUseCase` / `VerifyRegisterTokenUseCase`）に接続する

🤖 Generated with [Claude Code](https://claude.com/claude-code)