### PR TITLE
feat(ktcl-k8s): KICPのidServerB機能を追加

### DIFF
--- a/kise/build.gradle.kts
+++ b/kise/build.gradle.kts
@@ -37,6 +37,10 @@ kotlin {
         api(project(":ktse-sdk"))
         implementation("com.mysql:mysql-connector-j:9.7.0")
         implementation("com.zaxxer:HikariCP:7.0.2")
+
+        // KICP（idServer実装）
+        implementation(project(":kicp:kicp-domain"))
+        implementation(project(":kicp:kicp-usecase"))
     }
     sourceSets["jvmTest"].dependencies {
         implementation("io.ktor:ktor-server-test-host-jvm:${Version.KTOR}")

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
@@ -50,4 +50,8 @@ class KiseConfig(
 
     val oidcRedirectUri: String = environment.config.propertyOrNull("kise.oidc.redirectUri")?.getString()
         ?: "http://localhost:8080/callback"
+
+    // KICP設定（idServerBとして機能する際のpeerServerA URL）
+    val kicpPeerServerBaseUrl: String = environment.config.propertyOrNull("kise.kicp.peerServerBaseUrl")?.getString()
+        ?: "http://localhost:8080"
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/Main.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/Main.kt
@@ -7,11 +7,14 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.websocket.*
+import net.kigawa.keruta.kise.kicp.InMemoryRegisterTokenRepository
+import net.kigawa.keruta.kise.kicp.KicpFactory
 import net.kigawa.keruta.kise.oidc.IdTokenVerifier
 import net.kigawa.keruta.kise.oidc.OidcDiscoveryFetcher
 import net.kigawa.keruta.kise.oidc.PkceGenerator
 import net.kigawa.keruta.kise.oidc.model.OidcSession
 import net.kigawa.keruta.kise.route.CallbackRoute
+import net.kigawa.keruta.kise.route.KicpRoutes
 import net.kigawa.keruta.kise.route.LoginRoute
 import net.kigawa.keruta.kise.websocket.KiseWebSocketServer
 import kotlin.time.Duration.Companion.seconds
@@ -51,6 +54,16 @@ fun Application.module() {
     val callbackRoute = CallbackRoute(oidcDiscoveryFetcher, idTokenVerifier, config)
     val webSocketServer = KiseWebSocketServer(this, config)
 
+    // KICPコンポーネントの初期化
+    val kicpHttpClient = KicpFactory.createHttpClient()
+    val kicpTokenRepository = InMemoryRegisterTokenRepository()
+    val kicpRoutes = KicpRoutes(
+        loginUseCase = KicpFactory.createLoginUseCase(kicpHttpClient),
+        getRegisterTokenUseCase = KicpFactory.createGetRegisterTokenUseCase(kicpTokenRepository),
+        registerUseCase = KicpFactory.createRegisterUseCase(kicpHttpClient, config.kicpPeerServerBaseUrl),
+        verifyRegisterTokenUseCase = KicpFactory.createVerifyRegisterTokenUseCase(kicpTokenRepository),
+    )
+
     // ルーティング設定
     routing {
         // OIDCログインルート
@@ -61,5 +74,8 @@ fun Application.module() {
 
         // WebSocketエンドポイント
         webSocketServer.websocketModule(this)
+
+        // KICPエンドポイント（idServerA/B）
+        kicpRoutes.configure(this)
     }
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/InMemoryRegisterTokenRepository.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/InMemoryRegisterTokenRepository.kt
@@ -1,0 +1,23 @@
+package net.kigawa.keruta.kise.kicp
+
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRecord
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRepository
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.kodel.api.err.Res
+
+class InMemoryRegisterTokenRepository : RegisterTokenRepository {
+    private val storage = mutableMapOf<RegisterToken, RegisterTokenRecord>()
+
+    override suspend fun save(record: RegisterTokenRecord): Res<Unit, KicpErr> {
+        storage[record.token] = record
+        return Res.Ok(Unit)
+    }
+
+    override suspend fun find(token: RegisterToken): Res<RegisterTokenRecord?, KicpErr> = Res.Ok(storage[token])
+
+    override suspend fun delete(token: RegisterToken): Res<Unit, KicpErr> {
+        storage.remove(token)
+        return Res.Ok(Unit)
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/JwksRepositoryImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/JwksRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package net.kigawa.keruta.kise.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import net.kigawa.keruta.kicp.domain.err.JwksFetchErr
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.jwks.JwksUrl
+import net.kigawa.keruta.kicp.domain.repo.JwksRepository
+import net.kigawa.kodel.api.err.Res
+
+class JwksRepositoryImpl(
+    private val httpClient: HttpClient,
+) : JwksRepository {
+    override suspend fun get(url: JwksUrl): Res<Jwks, KicpErr> = try {
+        val jwks: Jwks = httpClient.get(url.value).body()
+        Res.Ok(jwks)
+    } catch (e: Exception) {
+        Res.Err(JwksFetchErr(url.value, e))
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/JwtVerifierImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/JwtVerifierImpl.kt
@@ -1,0 +1,53 @@
+package net.kigawa.keruta.kise.kicp
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import net.kigawa.keruta.kicp.domain.claims.TokenClaims
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.TokenVerificationErr
+import net.kigawa.keruta.kicp.domain.jwks.JwkKey
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.repo.JwtVerifier
+import net.kigawa.kodel.api.err.Res
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.Base64
+
+class JwtVerifierImpl : JwtVerifier {
+    override suspend fun verify(rawToken: String, jwks: Jwks): Res<TokenClaims, KicpErr> = try {
+        val decodedJwt = JWT.decode(rawToken)
+        val kid = decodedJwt.keyId
+
+        val jwkKey = jwks.keys.find { it.kid == kid }
+            ?: return Res.Err(TokenVerificationErr("適切なJWKキーが見つかりません: kid=$kid"))
+
+        val publicKey = buildRsaPublicKey(jwkKey)
+
+        val algorithm = when (jwkKey.alg) {
+            "RS256" -> Algorithm.RSA256(publicKey, null)
+            "RS384" -> Algorithm.RSA384(publicKey, null)
+            "RS512" -> Algorithm.RSA512(publicKey, null)
+            else -> return Res.Err(TokenVerificationErr("サポートされていないアルゴリズム: ${jwkKey.alg}"))
+        }
+
+        val verifiedJwt = JWT.require(algorithm).build().verify(rawToken)
+
+        Res.Ok(
+            TokenClaims(
+                issuer = verifiedJwt.issuer ?: "",
+                subject = verifiedJwt.subject ?: "",
+                audience = verifiedJwt.audience ?: emptyList(),
+            ),
+        )
+    } catch (e: Exception) {
+        Res.Err(TokenVerificationErr("JWTの検証に失敗しました: ${e.message}", e))
+    }
+
+    private fun buildRsaPublicKey(jwkKey: JwkKey): RSAPublicKey {
+        val n = BigInteger(1, Base64.getUrlDecoder().decode(jwkKey.n))
+        val e = BigInteger(1, Base64.getUrlDecoder().decode(jwkKey.e))
+        return KeyFactory.getInstance("RSA").generatePublic(RSAPublicKeySpec(n, e)) as RSAPublicKey
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/KicpFactory.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/KicpFactory.kt
@@ -1,0 +1,42 @@
+package net.kigawa.keruta.kise.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import net.kigawa.keruta.kicp.domain.repo.RegisterTokenRepository
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.keruta.kicp.usecase.login.LoginUseCase
+import net.kigawa.keruta.kicp.usecase.login.LoginUseCaseImpl
+import net.kigawa.keruta.kicp.usecase.register.GetRegisterTokenUseCase
+import net.kigawa.keruta.kicp.usecase.register.GetRegisterTokenUseCaseImpl
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCase
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCaseImpl
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterTokenUseCase
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterTokenUseCaseImpl
+import java.util.UUID
+
+object KicpFactory {
+    fun createHttpClient(): HttpClient = HttpClient(CIO) {
+        install(ContentNegotiation) { json() }
+    }
+
+    fun createLoginUseCase(httpClient: HttpClient): LoginUseCase = LoginUseCaseImpl(
+        jwksRepository = JwksRepositoryImpl(httpClient),
+        jwtVerifier = JwtVerifierImpl(),
+    )
+
+    fun createGetRegisterTokenUseCase(tokenRepository: RegisterTokenRepository): GetRegisterTokenUseCase = GetRegisterTokenUseCaseImpl(
+        tokenGenerator = { RegisterToken(UUID.randomUUID().toString()) },
+        tokenRepository = tokenRepository,
+        currentTimeMs = { System.currentTimeMillis() },
+    )
+
+    fun createRegisterUseCase(httpClient: HttpClient, peerServerBaseUrl: String): RegisterUseCase = RegisterUseCaseImpl(
+        jwksRepository = JwksRepositoryImpl(httpClient),
+        jwtVerifier = JwtVerifierImpl(),
+        peerServerClient = PeerServerClientImpl(httpClient, peerServerBaseUrl),
+    )
+
+    fun createVerifyRegisterTokenUseCase(tokenRepository: RegisterTokenRepository): VerifyRegisterTokenUseCase = VerifyRegisterTokenUseCaseImpl(tokenRepository = tokenRepository)
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/PeerServerClientImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/kicp/PeerServerClientImpl.kt
@@ -1,0 +1,41 @@
+package net.kigawa.keruta.kise.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.PeerVerificationErr
+import net.kigawa.keruta.kicp.domain.identity.RegisterId
+import net.kigawa.keruta.kicp.domain.repo.PeerServerClient
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.kodel.api.err.Res
+
+/** idServerA の verify-register エンドポイントに問い合わせる実装 */
+class PeerServerClientImpl(
+    private val httpClient: HttpClient,
+    private val peerServerBaseUrl: String,
+) : PeerServerClient {
+    override suspend fun verifyRegister(registerId: RegisterId, registerToken: RegisterToken): Res<Unit, KicpErr> = try {
+        val response: HttpResponse = httpClient.post("$peerServerBaseUrl/api/kicp/verify-register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                mapOf(
+                    "registerId" to registerId.value,
+                    "registerToken" to registerToken.value,
+                ),
+            )
+        }
+
+        if (response.status == HttpStatusCode.OK) {
+            Res.Ok(Unit)
+        } else {
+            Res.Err(PeerVerificationErr("登録トークンの検証に失敗しました: ${response.status}"))
+        }
+    } catch (e: Exception) {
+        Res.Err(PeerVerificationErr("peerサーバーとの通信に失敗しました: ${e.message}", e))
+    }
+}

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/KicpRoutes.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/KicpRoutes.kt
@@ -1,0 +1,191 @@
+package net.kigawa.keruta.kise.route
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+import net.kigawa.keruta.kicp.domain.identity.RegisterId
+import net.kigawa.keruta.kicp.domain.jwks.JwksUrl
+import net.kigawa.keruta.kicp.domain.token.OidcToken
+import net.kigawa.keruta.kicp.domain.token.ProviderToken
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.keruta.kicp.usecase.login.LoginInput
+import net.kigawa.keruta.kicp.usecase.login.LoginUseCase
+import net.kigawa.keruta.kicp.usecase.register.GetRegisterTokenInput
+import net.kigawa.keruta.kicp.usecase.register.GetRegisterTokenUseCase
+import net.kigawa.keruta.kicp.usecase.register.RegisterInput
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCase
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterInput
+import net.kigawa.keruta.kicp.usecase.register.VerifyRegisterTokenUseCase
+import net.kigawa.kodel.api.err.Res
+import net.kigawa.kodel.api.log.LoggerFactory
+
+@Serializable
+data class KicpGetRegisterTokenRequest(
+    val oidcToken: String,
+    val providerToken: String,
+    val oidcJwksUrl: String,
+    val providerJwksUrl: String,
+)
+
+@Serializable
+data class KicpRegisterRequest(
+    val oidcToken: String,
+    val providerToken: String,
+    val registerToken: String,
+    val oidcJwksUrl: String,
+    val providerJwksUrl: String,
+)
+
+@Serializable
+data class KicpVerifyRegisterRequest(
+    val registerId: String,
+    val registerToken: String,
+)
+
+/**
+ * KICPのidServer（A/B両方）エンドポイント
+ */
+class KicpRoutes(
+    private val loginUseCase: LoginUseCase,
+    private val getRegisterTokenUseCase: GetRegisterTokenUseCase,
+    private val registerUseCase: RegisterUseCase,
+    private val verifyRegisterTokenUseCase: VerifyRegisterTokenUseCase,
+) {
+    private val logger = LoggerFactory.get("KicpRoutes")
+
+    fun configure(route: Route) = route.route("/api/kicp") {
+        // idServerA: 登録トークン発行
+        post("/get-register-token") {
+            try {
+                val request = call.receive<KicpGetRegisterTokenRequest>()
+
+                val loginInput = LoginInput(
+                    oidcToken = OidcToken(request.oidcToken),
+                    oidcJwksUrl = JwksUrl(request.oidcJwksUrl),
+                    providerToken = ProviderToken(request.providerToken),
+                    providerJwksUrl = JwksUrl(request.providerJwksUrl),
+                )
+                val identityId = when (val result = loginUseCase.login(loginInput)) {
+                    is Res.Err -> {
+                        logger.warning("KICP認証失敗: ${result.err.message}")
+                        call.respond(
+                            HttpStatusCode.Unauthorized,
+                            mapOf("success" to false, "message" to "認証に失敗しました: ${result.err.message}"),
+                        )
+                        return@post
+                    }
+                    is Res.Ok -> result.value
+                }
+
+                when (val result = getRegisterTokenUseCase.getRegisterToken(GetRegisterTokenInput(identityId))) {
+                    is Res.Ok -> {
+                        logger.info("KICP登録トークン発行: identityId=${identityId.value}")
+                        call.respond(
+                            HttpStatusCode.OK,
+                            mapOf("success" to true, "registerToken" to result.value.value),
+                        )
+                    }
+                    is Res.Err -> {
+                        logger.warning("KICP登録トークン発行失敗: ${result.err.message}")
+                        call.respond(
+                            HttpStatusCode.InternalServerError,
+                            mapOf("success" to false, "message" to "登録トークンの発行に失敗しました: ${result.err.message}"),
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                logger.severe("KICP get-register-token エラー: ${e.message}")
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    mapOf("success" to false, "message" to "エラー: ${e.message}"),
+                )
+            }
+        }
+
+        // idServerB: 登録フロー
+        post("/register") {
+            try {
+                val request = call.receive<KicpRegisterRequest>()
+
+                val input = RegisterInput(
+                    oidcToken = OidcToken(request.oidcToken),
+                    oidcJwksUrl = JwksUrl(request.oidcJwksUrl),
+                    providerToken = ProviderToken(request.providerToken),
+                    providerJwksUrl = JwksUrl(request.providerJwksUrl),
+                    registerToken = RegisterToken(request.registerToken),
+                )
+
+                when (val result = registerUseCase.register(input)) {
+                    is Res.Ok -> {
+                        logger.info("KICP登録完了: identityId=${result.value.value}")
+                        call.respond(
+                            HttpStatusCode.OK,
+                            mapOf(
+                                "success" to true,
+                                "message" to "登録が完了しました",
+                                "identityId" to result.value.value,
+                            ),
+                        )
+                    }
+                    is Res.Err -> {
+                        logger.warning("KICP登録失敗: ${result.err.message}")
+                        call.respond(
+                            HttpStatusCode.BadRequest,
+                            mapOf("success" to false, "message" to "登録に失敗しました: ${result.err.message}"),
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                logger.severe("KICP register エラー: ${e.message}")
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    mapOf("success" to false, "message" to "エラー: ${e.message}"),
+                )
+            }
+        }
+
+        // idServerA: 登録トークン検証
+        post("/verify-register") {
+            try {
+                val request = call.receive<KicpVerifyRegisterRequest>()
+
+                val input = VerifyRegisterInput(
+                    registerId = RegisterId(request.registerId),
+                    registerToken = RegisterToken(request.registerToken),
+                    currentTimeMs = System.currentTimeMillis(),
+                )
+
+                when (val result = verifyRegisterTokenUseCase.verify(input)) {
+                    is Res.Ok -> {
+                        logger.info("KICP検証成功: identityId=${result.value.value}")
+                        call.respond(
+                            HttpStatusCode.OK,
+                            mapOf(
+                                "success" to true,
+                                "message" to "登録トークンの検証に成功しました",
+                                "identityId" to result.value.value,
+                            ),
+                        )
+                    }
+                    is Res.Err -> {
+                        logger.warning("KICP検証失敗: ${result.err.message}")
+                        call.respond(
+                            HttpStatusCode.BadRequest,
+                            mapOf("success" to false, "message" to "検証に失敗しました: ${result.err.message}"),
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                logger.severe("KICP verify-register エラー: ${e.message}")
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    mapOf("success" to false, "message" to "エラー: ${e.message}"),
+                )
+            }
+        }
+    }
+}

--- a/ktcl-k8s/build.gradle.kts
+++ b/ktcl-k8s/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(project(":ktcp-sdk:ktcp-infra-client"))
     implementation(project(":kodel:api"))
 
+    // KICP（idServerB実装）
+    implementation(project(":kicp:kicp-domain"))
+    implementation(project(":kicp:kicp-usecase"))
+
     // Ktor WebSocket Client
     implementation("io.ktor:ktor-client-core:${Version.KTOR}")
     implementation("io.ktor:ktor-client-cio:${Version.KTOR}")

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/config/KtseConfig.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/config/KtseConfig.kt
@@ -10,6 +10,8 @@ data class KtseConfig(
     val queueId: Long,
     val providerAudience: String,
 ) {
+    val baseUrl: String get() = "${if (useTls) "https" else "http"}://$host:$port"
+
     companion object {
         fun fromEnvironment(): KtseConfig = KtseConfig(
             host = System.getenv("KTSE_HOST") ?: "localhost",

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/JwksRepositoryImpl.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/JwksRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package net.kigawa.keruta.ktcl.k8s.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import net.kigawa.keruta.kicp.domain.err.JwksFetchErr
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.jwks.JwksUrl
+import net.kigawa.keruta.kicp.domain.repo.JwksRepository
+import net.kigawa.kodel.api.err.Res
+
+class JwksRepositoryImpl(
+    private val httpClient: HttpClient,
+) : JwksRepository {
+    override suspend fun get(url: JwksUrl): Res<Jwks, KicpErr> = try {
+        val jwks: Jwks = httpClient.get(url.value).body()
+        Res.Ok(jwks)
+    } catch (e: Exception) {
+        Res.Err(JwksFetchErr(url.value, e))
+    }
+}

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/JwtVerifierImpl.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/JwtVerifierImpl.kt
@@ -1,0 +1,53 @@
+package net.kigawa.keruta.ktcl.k8s.kicp
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import net.kigawa.keruta.kicp.domain.claims.TokenClaims
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.TokenVerificationErr
+import net.kigawa.keruta.kicp.domain.jwks.JwkKey
+import net.kigawa.keruta.kicp.domain.jwks.Jwks
+import net.kigawa.keruta.kicp.domain.repo.JwtVerifier
+import net.kigawa.kodel.api.err.Res
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.Base64
+
+class JwtVerifierImpl : JwtVerifier {
+    override suspend fun verify(rawToken: String, jwks: Jwks): Res<TokenClaims, KicpErr> = try {
+        val decodedJwt = JWT.decode(rawToken)
+        val kid = decodedJwt.keyId
+
+        val jwkKey = jwks.keys.find { it.kid == kid }
+            ?: return Res.Err(TokenVerificationErr("適切なJWKキーが見つかりません: kid=$kid"))
+
+        val publicKey = buildRsaPublicKey(jwkKey)
+
+        val algorithm = when (jwkKey.alg) {
+            "RS256" -> Algorithm.RSA256(publicKey, null)
+            "RS384" -> Algorithm.RSA384(publicKey, null)
+            "RS512" -> Algorithm.RSA512(publicKey, null)
+            else -> return Res.Err(TokenVerificationErr("サポートされていないアルゴリズム: ${jwkKey.alg}"))
+        }
+
+        val verifiedJwt = JWT.require(algorithm).build().verify(rawToken)
+
+        Res.Ok(
+            TokenClaims(
+                issuer = verifiedJwt.issuer ?: "",
+                subject = verifiedJwt.subject ?: "",
+                audience = verifiedJwt.audience ?: emptyList(),
+            ),
+        )
+    } catch (e: Exception) {
+        Res.Err(TokenVerificationErr("JWTの検証に失敗しました: ${e.message}", e))
+    }
+
+    private fun buildRsaPublicKey(jwkKey: JwkKey): RSAPublicKey {
+        val n = BigInteger(1, Base64.getUrlDecoder().decode(jwkKey.n))
+        val e = BigInteger(1, Base64.getUrlDecoder().decode(jwkKey.e))
+        return KeyFactory.getInstance("RSA").generatePublic(RSAPublicKeySpec(n, e)) as RSAPublicKey
+    }
+}

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/KicpFactory.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/KicpFactory.kt
@@ -1,0 +1,29 @@
+package net.kigawa.keruta.ktcl.k8s.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import net.kigawa.keruta.kicp.usecase.login.LoginUseCase
+import net.kigawa.keruta.kicp.usecase.login.LoginUseCaseImpl
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCase
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCaseImpl
+
+object KicpFactory {
+    fun createHttpClient(): HttpClient = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json()
+        }
+    }
+
+    fun createLoginUseCase(httpClient: HttpClient): LoginUseCase = LoginUseCaseImpl(
+        jwksRepository = JwksRepositoryImpl(httpClient),
+        jwtVerifier = JwtVerifierImpl(),
+    )
+
+    fun createRegisterUseCase(httpClient: HttpClient, ktseBaseUrl: String): RegisterUseCase = RegisterUseCaseImpl(
+        jwksRepository = JwksRepositoryImpl(httpClient),
+        jwtVerifier = JwtVerifierImpl(),
+        peerServerClient = PeerServerClientImpl(httpClient, ktseBaseUrl),
+    )
+}

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/PeerServerClientImpl.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/kicp/PeerServerClientImpl.kt
@@ -1,0 +1,41 @@
+package net.kigawa.keruta.ktcl.k8s.kicp
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import net.kigawa.keruta.kicp.domain.err.KicpErr
+import net.kigawa.keruta.kicp.domain.err.PeerVerificationErr
+import net.kigawa.keruta.kicp.domain.identity.RegisterId
+import net.kigawa.keruta.kicp.domain.repo.PeerServerClient
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.kodel.api.err.Res
+
+/** ktse（idServerA）の verify-register エンドポイントに問い合わせる実装 */
+class PeerServerClientImpl(
+    private val httpClient: HttpClient,
+    private val ktseBaseUrl: String,
+) : PeerServerClient {
+    override suspend fun verifyRegister(registerId: RegisterId, registerToken: RegisterToken): Res<Unit, KicpErr> = try {
+        val response: HttpResponse = httpClient.post("$ktseBaseUrl/api/kicp/verify-register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                mapOf(
+                    "registerId" to registerId.value,
+                    "registerToken" to registerToken.value,
+                ),
+            )
+        }
+
+        if (response.status == HttpStatusCode.OK) {
+            Res.Ok(Unit)
+        } else {
+            Res.Err(PeerVerificationErr("登録トークンの検証に失敗しました: ${response.status}"))
+        }
+    } catch (e: Exception) {
+        Res.Err(PeerVerificationErr("ktseとの通信に失敗しました: ${e.message}", e))
+    }
+}

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/route/KicpRoutes.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/route/KicpRoutes.kt
@@ -1,0 +1,79 @@
+package net.kigawa.keruta.ktcl.k8s.route
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+import net.kigawa.keruta.kicp.domain.jwks.JwksUrl
+import net.kigawa.keruta.kicp.domain.token.OidcToken
+import net.kigawa.keruta.kicp.domain.token.ProviderToken
+import net.kigawa.keruta.kicp.domain.token.RegisterToken
+import net.kigawa.keruta.kicp.usecase.register.RegisterInput
+import net.kigawa.keruta.kicp.usecase.register.RegisterUseCase
+import net.kigawa.kodel.api.err.Res
+import net.kigawa.kodel.api.log.LoggerFactory
+
+@Serializable
+data class KicpRegisterRequest(
+    val oidcToken: String,
+    val providerToken: String,
+    val registerToken: String,
+    val oidcJwksUrl: String,
+    val providerJwksUrl: String,
+)
+
+/** KICPのidServerB側エンドポイント */
+class KicpRoutes(
+    private val registerUseCase: RegisterUseCase,
+) {
+    private val logger = LoggerFactory.get("KicpRoutes")
+
+    fun configure(route: Route) = route.route("/api/kicp") {
+        post("/register") {
+            try {
+                val request = call.receive<KicpRegisterRequest>()
+
+                val input = RegisterInput(
+                    oidcToken = OidcToken(request.oidcToken),
+                    oidcJwksUrl = JwksUrl(request.oidcJwksUrl),
+                    providerToken = ProviderToken(request.providerToken),
+                    providerJwksUrl = JwksUrl(request.providerJwksUrl),
+                    registerToken = RegisterToken(request.registerToken),
+                )
+
+                when (val result = registerUseCase.register(input)) {
+                    is Res.Ok -> {
+                        logger.info("KICP登録完了: identityId=${result.value.value}")
+                        call.respond(
+                            HttpStatusCode.OK,
+                            mapOf(
+                                "success" to true,
+                                "message" to "登録が完了しました",
+                                "identityId" to result.value.value,
+                            ),
+                        )
+                    }
+                    is Res.Err -> {
+                        logger.warning("KICP登録失敗: ${result.err.message}")
+                        call.respond(
+                            HttpStatusCode.BadRequest,
+                            mapOf(
+                                "success" to false,
+                                "message" to "登録に失敗しました: ${result.err.message}",
+                            ),
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                logger.severe("KICP登録エラー: ${e.message}")
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    mapOf("success" to false, "message" to "エラー: ${e.message}"),
+                )
+            }
+        }
+    }
+}

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/route/RouteModule.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/route/RouteModule.kt
@@ -7,6 +7,7 @@ import net.kigawa.keruta.ktcl.k8s.auth.AuthenticationHelper
 import net.kigawa.keruta.ktcl.k8s.auth.OidcDiscoveryFetcher
 import net.kigawa.keruta.ktcl.k8s.auth.PkceGenerator
 import net.kigawa.keruta.ktcl.k8s.config.AppConfig
+import net.kigawa.keruta.ktcl.k8s.kicp.KicpFactory
 import net.kigawa.keruta.ktcl.k8s.login.*
 import net.kigawa.keruta.ktcl.k8s.persist.DbModule
 import net.kigawa.keruta.ktcp.base.auth.jwks.JwksProvider
@@ -74,12 +75,17 @@ class RouteModule(
         )
         val tokenRoute = TokenRoute(oidcDiscoveryFetcher, idpConfig)
 
+        val kicpHttpClient = KicpFactory.createHttpClient()
+        val kicpRegisterUseCase = KicpFactory.createRegisterUseCase(kicpHttpClient, appConfig.ktse.baseUrl)
+        val kicpRoutes = KicpRoutes(kicpRegisterUseCase)
+
         application.routing {
             configRoutes.configureConfigRoutes(this)
             staticRoutes.configure(this)
             loginRoute.configure(this)
             tokenRoute.configure(this)
             loginCallbackRoute.configure(this)
+            kicpRoutes.configure(this)
         }
     }
 }


### PR DESCRIPTION
## 概要

ktcl-k8sにKICP（クロスドメインIDフェデレーションプロトコル）のidServerB機能を追加しました。
ユーザーはKICPフローを通じてktcl-k8sにログインできるようになります。

## 変更内容

### 新規追加
- `ktcl-k8s/kicp/JwksRepositoryImpl.kt` - HTTPでJWKSを取得するポート実装
- `ktcl-k8s/kicp/JwtVerifierImpl.kt` - Auth0 java-jwtを使ったJWT検証実装
- `ktcl-k8s/kicp/PeerServerClientImpl.kt` - ktse（idServerA）の `/api/kicp/verify-register` に問い合わせる実装
- `ktcl-k8s/kicp/KicpFactory.kt` - KICP依存の手動DI組み立て
- `ktcl-k8s/route/KicpRoutes.kt` - `POST /api/kicp/register` エンドポイント（idServerB）

### 変更
- `build.gradle.kts` - `kicp-domain`, `kicp-usecase` 依存を追加
- `config/KtseConfig.kt` - `baseUrl` プロパティを追加（PeerServerClientが使用）
- `route/RouteModule.kt` - `KicpRoutes` を組み込み

## KICPログインフロー

```
1. フロントエンドがktse（idServerA）からregisterTokenを取得
   POST /api/kicp/get-register-token
   { oidcToken, providerToken, oidcJwksUrl, providerJwksUrl }

2. フロントエンドがktcl-k8s（idServerB）に登録リクエストを送信
   POST /api/kicp/register
   { oidcToken, providerToken, registerToken, oidcJwksUrl, providerJwksUrl }

3. ktcl-k8sがRegisterUseCaseでトークンを検証し、
   ktseの /api/kicp/verify-register で確認

4. 登録完了 → identityId を返却
```

## テスト計画

- [ ] `./gradlew :ktcl-k8s:build` でビルド成功確認 ✅
- [ ] `./gradlew :ktcl-k8s:ktlintCheck` でlintチェック成功 ✅
- [ ] ktseとktcl-k8sを起動してKICPフローを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)