### PR TITLE
feat(ktcl-front,kise): kiseを使ったログイン機能を実装

### DIFF
--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/KiseConfig.kt
@@ -51,6 +51,9 @@ class KiseConfig(
     val oidcRedirectUri: String = environment.config.propertyOrNull("kise.oidc.redirectUri")?.getString()
         ?: "http://localhost:8080/callback"
 
+    val frontendBaseUrl: String = environment.config.propertyOrNull("kise.frontend.baseUrl")?.getString()
+        ?: "http://localhost:5173"
+
     // KICP設定（idServerBとして機能する際のpeerServerA URL）
     val kicpPeerServerBaseUrl: String = environment.config.propertyOrNull("kise.kicp.peerServerBaseUrl")?.getString()
         ?: "http://localhost:8080"

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/Main.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/Main.kt
@@ -7,6 +7,7 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.websocket.*
+import net.kigawa.keruta.kise.jwt.JwtIssuerImpl
 import net.kigawa.keruta.kise.kicp.InMemoryRegisterTokenRepository
 import net.kigawa.keruta.kise.kicp.KicpFactory
 import net.kigawa.keruta.kise.oidc.IdTokenVerifier
@@ -14,9 +15,11 @@ import net.kigawa.keruta.kise.oidc.OidcDiscoveryFetcher
 import net.kigawa.keruta.kise.oidc.PkceGenerator
 import net.kigawa.keruta.kise.oidc.model.OidcSession
 import net.kigawa.keruta.kise.route.CallbackRoute
+import net.kigawa.keruta.kise.route.JwksRoute
 import net.kigawa.keruta.kise.route.KicpRoutes
 import net.kigawa.keruta.kise.route.LoginRoute
 import net.kigawa.keruta.kise.websocket.KiseWebSocketServer
+import net.kigawa.kodel.api.log.LoggerFactory
 import kotlin.time.Duration.Companion.seconds
 
 fun main(args: Array<String>) {
@@ -46,12 +49,34 @@ fun Application.module() {
         masking = false
     }
 
+    val logger = LoggerFactory.get("KiseMain")
+
+    // JWT発行コンポーネントの初期化（キーが設定されていない場合はnull）
+    val jwtIssuerImpl: JwtIssuerImpl? = if (config.jwtPublicKey.isNotBlank() && config.jwtPrivateKey.isNotBlank()) {
+        try {
+            JwtIssuerImpl.fromPem(
+                publicKeyPem = config.jwtPublicKey,
+                privateKeyPem = config.jwtPrivateKey,
+                issuer = config.issuer,
+                audience = config.audience,
+                expiresInMs = config.tokenExpiresInMs,
+            )
+        } catch (e: Exception) {
+            logger.severe("Failed to initialize JwtIssuerImpl: ${e.message}")
+            null
+        }
+    } else {
+        logger.warning("JWT keys not configured. Token issuance disabled.")
+        null
+    }
+
     // OIDCコンポーネントの初期化
     val oidcDiscoveryFetcher = OidcDiscoveryFetcher()
     val pkceGenerator = PkceGenerator()
     val idTokenVerifier = IdTokenVerifier()
     val loginRoute = LoginRoute(oidcDiscoveryFetcher, pkceGenerator, config)
-    val callbackRoute = CallbackRoute(oidcDiscoveryFetcher, idTokenVerifier, config)
+    val callbackRoute = CallbackRoute(oidcDiscoveryFetcher, idTokenVerifier, config, jwtIssuerImpl)
+    val jwksRoute = JwksRoute(config, jwtIssuerImpl)
     val webSocketServer = KiseWebSocketServer(this, config)
 
     // KICPコンポーネントの初期化
@@ -77,5 +102,8 @@ fun Application.module() {
 
         // KICPエンドポイント（idServerA/B）
         kicpRoutes.configure(this)
+
+        // JWKS・OIDCディスカバリエンドポイント
+        jwksRoute.configure(this)
     }
 }

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/jwt/JwtIssuerImpl.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/jwt/JwtIssuerImpl.kt
@@ -28,21 +28,27 @@ class JwtIssuerImpl(
         issuer: String,
         subject: String,
         audience: String,
+        preferredUsername: String?,
     ): String {
         val expiresAt = Date(System.currentTimeMillis() + expiresInMs)
         val issuedAt = Date()
 
-        return JWT.create()
+        val builder = JWT.create()
             .withIssuer(issuer)
             .withAudience(audience)
-            .withSubject(userId.toString())
+            .withSubject(subject)
             .withClaim("userId", userId)
-            .withClaim("iss", issuer)
-            .withClaim("sub", subject)
             .withIssuedAt(issuedAt)
             .withExpiresAt(expiresAt)
-            .sign(algorithm)
+
+        if (preferredUsername != null) {
+            builder.withClaim("preferred_username", preferredUsername)
+        }
+
+        return builder.sign(algorithm)
     }
+
+    fun getPublicKey(): java.security.interfaces.RSAPublicKey = publicKey
 
     /**
      * 設定からJwtIssuerを生成する

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/oidc/IdTokenVerifier.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/oidc/IdTokenVerifier.kt
@@ -10,6 +10,13 @@ import net.kigawa.keruta.kise.oidc.model.OidcSession
 import net.kigawa.kodel.api.log.LoggerFactory
 import java.util.concurrent.TimeUnit
 
+data class IdTokenClaims(
+    val subject: String,
+    val preferredUsername: String?,
+    val name: String?,
+    val email: String?,
+)
+
 class IdTokenVerifier {
     private val logger = LoggerFactory.get("IdTokenVerifier")
 
@@ -17,7 +24,7 @@ class IdTokenVerifier {
         idToken: String,
         discoveryResponse: OidcDiscoveryResponse,
         oidcSession: OidcSession,
-    ): String? = try {
+    ): IdTokenClaims? = try {
         // JWKSエンドポイントから公開鍵を取得
         val jwkProvider: JwkProvider = JwkProviderBuilder(discoveryResponse.jwksUri)
             .cached(10, 24, TimeUnit.HOURS)
@@ -41,8 +48,12 @@ class IdTokenVerifier {
 
         val verifiedJWT = verifier.verify(idToken)
 
-        // ユーザーのsubject（ユニークID）を返す
-        verifiedJWT.subject
+        IdTokenClaims(
+            subject = verifiedJWT.subject,
+            preferredUsername = verifiedJWT.getClaim("preferred_username")?.asString(),
+            name = verifiedJWT.getClaim("name")?.asString(),
+            email = verifiedJWT.getClaim("email")?.asString(),
+        )
     } catch (e: Exception) {
         logger.severe("Failed to verify ID token: ${e.message}")
         null

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/CallbackRoute.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/CallbackRoute.kt
@@ -17,12 +17,14 @@ import net.kigawa.keruta.kise.oidc.IdTokenVerifier
 import net.kigawa.keruta.kise.oidc.OidcDiscoveryFetcher
 import net.kigawa.keruta.kise.oidc.model.OidcSession
 import net.kigawa.keruta.kise.oidc.model.TokenResponse
+import net.kigawa.keruta.kise.usecase.auth.JwtIssuer
 import net.kigawa.kodel.api.log.LoggerFactory
 
 class CallbackRoute(
     private val oidcDiscoveryFetcher: OidcDiscoveryFetcher,
     private val idTokenVerifier: IdTokenVerifier,
     private val config: KiseConfig,
+    private val jwtIssuer: JwtIssuer? = null,
 ) {
     private val logger = LoggerFactory.get("CallbackRoute")
 
@@ -87,16 +89,30 @@ class CallbackRoute(
                 return
             }
 
-            val userSubject = idTokenVerifier.verify(idToken, discoveryResponse, oidcSession)
-            if (userSubject == null) {
+            val claims = idTokenVerifier.verify(idToken, discoveryResponse, oidcSession)
+            if (claims == null) {
                 call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid ID token"))
                 return
             }
 
-            logger.info("Login successful for user: $userSubject (issuer: ${oidcSession.issuer})")
+            logger.info("Login successful for user: ${claims.subject} (issuer: ${oidcSession.issuer})")
 
-            // フロントエンドにリダイレクト
-            call.respondRedirect("/")
+            if (jwtIssuer == null) {
+                logger.warning("JwtIssuer not configured, redirecting to frontend root")
+                call.respondRedirect(config.frontendBaseUrl)
+                return
+            }
+
+            val token = jwtIssuer.createToken(
+                userId = 0L,
+                issuer = config.issuer,
+                subject = claims.subject,
+                audience = config.audience,
+                preferredUsername = claims.preferredUsername ?: claims.name,
+            )
+
+            val callbackUrl = "${config.frontendBaseUrl}/auth/callback?token=${token.encodeURLParameter()}"
+            call.respondRedirect(callbackUrl)
         } catch (e: Exception) {
             logger.severe("Failed to process OIDC callback: ${e.message}")
             call.respond(

--- a/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/JwksRoute.kt
+++ b/kise/src/jvmMain/kotlin/net/kigawa/keruta/kise/route/JwksRoute.kt
@@ -1,0 +1,62 @@
+package net.kigawa.keruta.kise.route
+
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import net.kigawa.keruta.kise.KiseConfig
+import net.kigawa.keruta.kise.jwt.JwtIssuerImpl
+import java.math.BigInteger
+import java.util.Base64
+
+class JwksRoute(
+    private val config: KiseConfig,
+    private val jwtIssuerImpl: JwtIssuerImpl?,
+) {
+    fun configure(route: Route) {
+        route.get("/.well-known/jwks.json") {
+            val keys = if (jwtIssuerImpl != null) {
+                val pub = jwtIssuerImpl.getPublicKey()
+                listOf(
+                    mapOf(
+                        "kty" to "RSA",
+                        "use" to "sig",
+                        "alg" to "RS256",
+                        "kid" to "kise-key-1",
+                        "n" to pub.modulus.toBase64UrlUnsigned(),
+                        "e" to pub.publicExponent.toBase64UrlUnsigned(),
+                    ),
+                )
+            } else {
+                emptyList<Map<String, Any>>()
+            }
+            call.respond(mapOf("keys" to keys))
+        }
+
+        route.get("/.well-known/openid-configuration") {
+            // jwks_uri はリクエストを受けたサーバーの URL を使用する
+            val req = call.request.local
+            val port = if ((req.scheme == "https" && req.serverPort == 443) ||
+                (req.scheme == "http" && req.serverPort == 80)
+            ) {
+                ""
+            } else {
+                ":${req.serverPort}"
+            }
+            val serverBase = "${req.scheme}://${req.serverHost}$port"
+            call.respond(
+                mapOf(
+                    "issuer" to config.issuer,
+                    "jwks_uri" to "$serverBase/.well-known/jwks.json",
+                    "response_types_supported" to listOf("code"),
+                    "subject_types_supported" to listOf("public"),
+                    "id_token_signing_alg_values_supported" to listOf("RS256"),
+                ),
+            )
+        }
+    }
+
+    private fun BigInteger.toBase64UrlUnsigned(): String {
+        val bytes = this.toByteArray()
+        val unsigned = if (bytes.isNotEmpty() && bytes[0] == 0.toByte()) bytes.drop(1).toByteArray() else bytes
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(unsigned)
+    }
+}

--- a/kise/src/jvmMain/resources/application.conf
+++ b/kise/src/jvmMain/resources/application.conf
@@ -49,4 +49,8 @@ kise {
         clientId = "kise-client"
         redirectUri = "http://localhost:8080/callback"
     }
+    frontend {
+        baseUrl = "http://localhost:5173"
+        baseUrl = ${?KISE_FRONTEND_BASE_URL}
+    }
 }

--- a/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
+++ b/kise/usecase/src/commonMain/kotlin/net/kigawa/keruta/kise/usecase/auth/AuthenticateUseCase.kt
@@ -120,5 +120,11 @@ class AuthenticateUseCase(
  * JWT発行インターフェース
  */
 interface JwtIssuer {
-    fun createToken(userId: Long, issuer: String, subject: String, audience: String): String
+    fun createToken(
+        userId: Long,
+        issuer: String,
+        subject: String,
+        audience: String,
+        preferredUsername: String? = null,
+    ): String
 }

--- a/ktcl-front/.env.example
+++ b/ktcl-front/.env.example
@@ -1,11 +1,9 @@
 VITE_WEBSOCKET_URL=ws://localhost:8080/ws/ktcp
 VITE_PROVIDER_PRESETS=[{"id":"keycloak","name":"Keycloak","issuer":"https://auth.example.com/realms/myrealm","description":"Keycloakを使用するプロバイダー"}]
-VITE_KEYCLOAK_URL=https://user.kigawa.net/
-VITE_KEYCLOAK_REALM=develop
-VITE_KEYCLOAK_CLIENT_ID=keruta
+VITE_KISE_URL=http://localhost:8080
 SECRET=secret
 OWN_ISSUER=http://localhost:5173/
 PRIVATE_KEY=
 KTSE_AUD=keruta
-USER_ISSUER=https://user.kigawa.net/realms/develop
-USER_JWKS_URL=https://user.kigawa.net/realms/develop/protocol/openid-connect/certs
+# kise サーバーの URL（/.well-known/openid-configuration を提供する）
+USER_ISSUER=http://localhost:8080

--- a/ktcl-front/app/Config.ts
+++ b/ktcl-front/app/Config.ts
@@ -2,10 +2,7 @@ import {Url} from "./util/net/Url";
 
 const Config = {
     websocketUrl: Url.parse(import.meta.env.VITE_WEBSOCKET_URL),
-    keycloakUrl: import.meta.env.VITE_KEYCLOAK_URL,
-    keycloakRealm: import.meta.env.VITE_KEYCLOAK_REALM,
-    keycloakClientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID,
-    keycloakCheckLoginIframe: (import.meta.env.VITE_KEYCLOAK_CHECK_LOGIN_IFRAME || "true") == "true",
+    kiseUrl: import.meta.env.VITE_KISE_URL,
 } as const
 
 function validate() {

--- a/ktcl-front/app/ServerConfig.server.ts
+++ b/ktcl-front/app/ServerConfig.server.ts
@@ -2,6 +2,7 @@ const ServerConfig = {
     strPrivateKey: process.env.PRIVATE_KEY,
     ownIssuer: process.env.OWN_ISSUER,
     ktseAud: process.env.KTSE_AUD,
+    // kise サーバーの URL（/.well-known/openid-configuration を提供する）
     userIssuer: process.env.USER_ISSUER,
 } as const
 

--- a/ktcl-front/app/auth.ts
+++ b/ktcl-front/app/auth.ts
@@ -7,6 +7,7 @@ export namespace Auth {
 
     async function getOidcConfig() {
         if (cachedOidcConfig) return cachedOidcConfig
+        // kise の /.well-known/openid-configuration から jwks_uri を取得する
         const issuerUrl = ServerConfig.userIssuer.replace(/\/$/, "")
         const response = await fetch(`${issuerUrl}/.well-known/openid-configuration`)
         if (!response.ok) throw new Error(`Failed to fetch OIDC configuration: ${response.statusText}`)

--- a/ktcl-front/app/components/api/AuthedKtseProvider.tsx
+++ b/ktcl-front/app/components/api/AuthedKtseProvider.tsx
@@ -1,6 +1,6 @@
 import {createContext, ReactNode, useContext, useEffect, useState} from "react";
 import {useKtclApiState} from "./KtclApiProvider";
-import {useKeycloakState} from "../auth/Keycloak";
+import {useKiseAuthState} from "../auth/KiseAuth";
 import {useKtseApiState} from "./KtseApiProvider";
 import {useStateFlow} from "../../util/StateFlow";
 import {AuthedKtseApi} from "./AuthedKtseApi";
@@ -15,15 +15,15 @@ export function AuthedKtseProvider(
     }
 ) {
     const [AuthedKtseState, setAuthedKtseState] = useState<AuthedKtseState>({state: "unloaded"});
-    const kc = useKeycloakState()
+    const auth = useKiseAuthState()
     const ktcl = useKtclApiState()
     const ktse = useKtseApiState()
     useEffect(() => {
-        if (kc.state != "authenticated") return;
+        if (auth.state != "authenticated") return;
         if (ktcl.state != "loaded") return;
         if (ktse.state != "loaded") return;
         console.log("Sending auth request...")
-        const userToken = kc.getToken()
+        const userToken = auth.getToken()
         const serverToken = userToken.then(value => {
             return ktcl.ktclApi.getServerToken(value)
         })
@@ -32,7 +32,7 @@ export function AuthedKtseProvider(
         }).catch(reason => {
             console.error("Auth request failed:", reason)
         })
-    }, [kc, ktcl, ktse]);
+    }, [auth, ktcl, ktse]);
     useStateFlow(
         ktse.state == "loaded" ? ktse.ktclApi.auth.getAuthSuccessReceiver() : undefined,
         () => {

--- a/ktcl-front/app/components/auth/AuthButton.tsx
+++ b/ktcl-front/app/components/auth/AuthButton.tsx
@@ -1,23 +1,21 @@
-import {useKeycloakState} from "./Keycloak";
-import {useUserProfileState} from "../user/UserProfile";
+import {useKiseAuthState} from "./KiseAuth";
 
 
 const AuthButton = () => {
-    const kcState = useKeycloakState()
-    const userProfile = useUserProfileState()
-    if (kcState.state == "unloaded") return <div className="text-xs">loading</div>
-    if (kcState.state == "unauthenticated") return (
-        <button onClick={kcState.login} className="login-btn text-xs md:text-sm">
+    const authState = useKiseAuthState()
+    if (authState.state == "unloaded") return <div className="text-xs">loading</div>
+    if (authState.state == "unauthenticated") return (
+        <button onClick={authState.login} className="login-btn text-xs md:text-sm">
             Login
         </button>
     )
 
-    const username = userProfile.state == "loaded" ? userProfile.value.username : "User"
+    const username = authState.preferredUsername ?? authState.sub
     return (
         <div className="flex items-center gap-2 md:gap-4">
             <span className="hidden sm:inline text-xs md:text-sm">Welcome, {username}!</span>
             <span className="sm:hidden text-xs">{username}</span>
-            <button onClick={kcState.logout} className="logout-btn text-xs md:text-sm">
+            <button onClick={authState.logout} className="logout-btn text-xs md:text-sm">
                 Logout
             </button>
         </div>

--- a/ktcl-front/app/components/auth/KiseAuth.tsx
+++ b/ktcl-front/app/components/auth/KiseAuth.tsx
@@ -1,0 +1,97 @@
+import {createContext, type ReactNode, useContext, useEffect, useState} from "react";
+import Config from "../../Config";
+
+const KISE_TOKEN_KEY = "kise_token"
+
+export type KiseAuthState = {
+    state: "unloaded"
+} | {
+    state: "unauthenticated"
+    login(): void
+} | {
+    state: "authenticated"
+    logout(): void
+    getToken(): Promise<string>
+    sub: string
+    preferredUsername: string | null
+}
+
+const Context = createContext<KiseAuthState>({state: "unloaded"})
+
+export function KiseAuthProvider({children}: { children: ReactNode }) {
+    const [state, setState] = useState<KiseAuthState>({state: "unloaded"})
+
+    useEffect(() => {
+        const token = sessionStorage.getItem(KISE_TOKEN_KEY)
+        if (token && !isTokenExpired(token)) {
+            const payload = decodeTokenPayload(token)
+            setState(makeAuthenticatedState(token, payload?.sub ?? "", payload?.preferred_username ?? null, setState))
+        } else {
+            if (token) sessionStorage.removeItem(KISE_TOKEN_KEY)
+            setState(makeUnauthenticatedState())
+        }
+    }, [])
+
+    return <Context.Provider value={state}>{children}</Context.Provider>
+}
+
+function makeUnauthenticatedState(): KiseAuthState {
+    return {
+        state: "unauthenticated",
+        login() {
+            window.location.href = `${Config.kiseUrl}/login`
+        },
+    }
+}
+
+function makeAuthenticatedState(
+    token: string,
+    sub: string,
+    preferredUsername: string | null,
+    setState: (state: KiseAuthState) => void,
+): KiseAuthState {
+    return {
+        state: "authenticated",
+        sub,
+        preferredUsername,
+        logout() {
+            sessionStorage.removeItem(KISE_TOKEN_KEY)
+            setState(makeUnauthenticatedState())
+        },
+        async getToken() {
+            if (isTokenExpired(token)) {
+                sessionStorage.removeItem(KISE_TOKEN_KEY)
+                setState(makeUnauthenticatedState())
+                throw new Error("Token expired")
+            }
+            return token
+        },
+    }
+}
+
+function decodeTokenPayload(token: string): Record<string, unknown> | null {
+    try {
+        return JSON.parse(atob(token.split(".")[1]))
+    } catch {
+        return null
+    }
+}
+
+function isTokenExpired(token: string): boolean {
+    try {
+        const payload = decodeTokenPayload(token)
+        const exp = payload?.exp
+        if (typeof exp !== "number") return true
+        return exp * 1000 < Date.now()
+    } catch {
+        return true
+    }
+}
+
+export function storeKiseToken(token: string) {
+    sessionStorage.setItem(KISE_TOKEN_KEY, token)
+}
+
+export function useKiseAuthState(): KiseAuthState {
+    return useContext(Context) ?? {state: "unloaded"}
+}

--- a/ktcl-front/app/components/auth/PrivateRoute.tsx
+++ b/ktcl-front/app/components/auth/PrivateRoute.tsx
@@ -1,23 +1,23 @@
 import type {ReactNode} from "react";
-import {useKeycloakState} from "./Keycloak";
+import {useKiseAuthState} from "./KiseAuth";
 
 interface PrivateRouteProps {
     children: ReactNode
 }
 
 const PrivateRoute = ({children}: PrivateRouteProps) => {
-    const kcState = useKeycloakState()
+    const authState = useKiseAuthState()
 
-    if (kcState.state == "unloaded") return <div>loading</div>
-    if (kcState.state == "unauthenticated") {
+    if (authState.state == "unloaded") return <div>loading</div>
+    if (authState.state == "unauthenticated") {
         return (
             <div className="private-route">
                 <h2>Authentication Required</h2>
                 <p>You need to log in to access this page.</p>
                 <button onClick={() => {
-                    kcState.login()
+                    authState.login()
                 }} className="login-btn">
-                    Login with Keycloak
+                    Login
                 </button>
             </div>
         )

--- a/ktcl-front/app/components/user/UserProfile.tsx
+++ b/ktcl-front/app/components/user/UserProfile.tsx
@@ -1,6 +1,5 @@
 import {createContext, type ReactNode, useContext, useEffect, useState} from "react";
-import {useKeycloakState} from "../auth/Keycloak";
-import type {KeycloakProfile} from "keycloak-js";
+import {useKiseAuthState} from "../auth/KiseAuth";
 
 
 const Context = createContext<UserProfileState>({state: "unloaded"});
@@ -12,13 +11,17 @@ export function UserProfileProvider(
         children: ReactNode
     }) {
     const [userProfile, setUserProfile] = useState<UserProfileState>({state: "unloaded"})
-    const kcState = useKeycloakState()
+    const authState = useKiseAuthState()
     useEffect(() => {
-        if (kcState.state != "authenticated") return
-        kcState.keycloak.loadUserProfile().then(value => {
-            setUserProfile({state: "loaded", value})
+        if (authState.state != "authenticated") return
+        setUserProfile({
+            state: "loaded",
+            value: {
+                username: authState.preferredUsername ?? authState.sub,
+                sub: authState.sub,
+            },
         })
-    }, [kcState.state]);
+    }, [authState.state]);
     return <Context.Provider
         value={userProfile}
         {...props}
@@ -35,5 +38,5 @@ export type UserProfileState = {
     state: "unloaded"
 } | {
     state: "loaded",
-    value: KeycloakProfile
+    value: { username: string; sub: string }
 }

--- a/ktcl-front/app/layout/RootProviders.tsx
+++ b/ktcl-front/app/layout/RootProviders.tsx
@@ -1,5 +1,5 @@
 import {ReactNode, useEffect, useState} from "react";
-import {KeycloakProvider} from "../components/auth/Keycloak";
+import {KiseAuthProvider} from "../components/auth/KiseAuth";
 import {UserProfileProvider} from "../components/user/UserProfile";
 
 import Config from "../Config";
@@ -29,7 +29,7 @@ export function RootProviders({children}: RootProvidersProps) {
     }
 
     return (
-        <KeycloakProvider>
+        <KiseAuthProvider>
             <UserProfileProvider>
                 <KtclApiProvider>
                     <WebsocketProvider wsUrl={Config.websocketUrl}>
@@ -41,6 +41,6 @@ export function RootProviders({children}: RootProvidersProps) {
                     </WebsocketProvider>
                 </KtclApiProvider>
             </UserProfileProvider>
-        </KeycloakProvider>
+        </KiseAuthProvider>
     );
 }

--- a/ktcl-front/app/routes.tsx
+++ b/ktcl-front/app/routes.tsx
@@ -16,4 +16,5 @@ export default [
     ]),
     route(".well-known/jwks.json", "./routes/jwks.ts"),
     route("api/token", "./routes/token.ts"),
+    route("auth/callback", "./routes/auth.callback.tsx"),
 ] satisfies RouteConfig;

--- a/ktcl-front/app/routes/auth.callback.tsx
+++ b/ktcl-front/app/routes/auth.callback.tsx
@@ -1,0 +1,16 @@
+import {useEffect} from "react"
+import {useSearchParams} from "react-router"
+
+export default function AuthCallback() {
+    const [searchParams] = useSearchParams()
+
+    useEffect(() => {
+        const token = searchParams.get("token")
+        if (token) {
+            sessionStorage.setItem("kise_token", token)
+        }
+        window.location.replace("/")
+    }, [])
+
+    return <div>ログイン処理中...</div>
+}


### PR DESCRIPTION
## Summary

- **kise**: OIDCコールバック後にJWTを発行し、フロントエンドのコールバックURLへリダイレクトするよう変更
- **kise**: `/.well-known/jwks.json` および `/.well-known/openid-configuration` エンドポイントを追加
- **ktcl-front**: Keycloak.js認証を廃止し、kiseリダイレクト認証（`KiseAuthProvider`）に置き換え
- **ktcl-front**: `/auth/callback` ルートを追加（kiseからのJWTを受け取り`sessionStorage`に保存）

## 認証フローの変更

**変更前**: ktcl-front → Keycloak（Keycloak.js SDK経由）

**変更後**:
```
ユーザー → ktcl-front /login → kise /login → Keycloak
→ kise /callback（JWT発行）→ ktcl-front /auth/callback（JWT保存）→ アプリ
```

## Test plan

- [ ] kiseでJWT用のRSAキーを設定した状態でログインフローが通ること
- [ ] `/auth/callback?token=...` でsessionStorageにトークンが保存されること
- [ ] ログアウト後に再ログインが求められること
- [ ] `ktse` へのWebSocket認証が成功すること
- [ ] kise未設定時（JWT keysなし）でも起動エラーにならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)