### PR TITLE
feat(ktse): /healthエンドポイントの追加とCI起動確認ジョブを実装

### DIFF
--- a/.github/workflows/ktse-check.yml
+++ b/.github/workflows/ktse-check.yml
@@ -16,3 +16,100 @@ jobs:
     with:
       dockerFile: './Dockerfile_ktse'
       gradleTask: ':ktse:shadowJar -x test'
+
+  health-check:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:9.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: keruta_test
+          MYSQL_USER: keruta
+          MYSQL_PASSWORD: keruta
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -u keruta -pkeruta"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          enable-configuration-cache: true
+
+      - name: Gradle cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Build shadowJar
+        run: ./gradlew :ktse:shadowJar -x test
+        env:
+          GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./
+          file: ./Dockerfile_ktse
+          push: false
+          load: true
+          tags: ktse:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start ktse server
+        run: |
+          docker run -d \
+            --name ktse-test \
+            --network host \
+            -e DB_JDBC_URL="jdbc:mysql://localhost:3306/keruta_test" \
+            -e DB_USERNAME="keruta" \
+            -e DB_PASSWORD="keruta" \
+            -e IDP_0_ISSUER="https://example.com/realms/test" \
+            -e IDP_0_AUDIENCE="keruta" \
+            -e PROVIDER_0_ISSUER="https://example.com/realms/test" \
+            -e PROVIDER_0_AUDIENCE="keruta" \
+            -e PROVIDER_0_NAME="test-provider" \
+            -e KTSE_JWT_SECRET="test-jwt-secret-key-for-ci-health-check-only" \
+            -e ZK_HOST="localhost:2181" \
+            ktse:test
+
+      - name: Wait for server to be ready
+        run: |
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "サーバーが起動しました"
+              exit 0
+            fi
+            echo "待機中... ($i/30) status=$STATUS"
+            sleep 3
+          done
+          echo "サーバーの起動に失敗しました"
+          docker logs ktse-test
+          exit 1
+
+      - name: ヘルスエンドポイントの確認
+        run: curl -f http://localhost:8080/health
+
+      - name: サーバーの停止
+        if: always()
+        run: docker stop ktse-test || true

--- a/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
+++ b/ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt
@@ -62,6 +62,10 @@ class KerutaTaskServer {
         routing {
             ws.websocketModule(this@routing)
 
+            get("/health") {
+                call.respond(HttpStatusCode.OK, mapOf("status" to "ok"))
+            }
+
             // kicpクライアント登録エンドポイント（idServerB側）
             post("/api/kicp/register") {
                 try {


### PR DESCRIPTION
## 概要

- `GET /health` エンドポイントを ktse サーバーに追加（認証不要、`{"status":"ok"}` を 200 で返す）
- `ktse-check.yml` に `health-check` ジョブを追加し、Dockerコンテナとして実際にサーバーを起動して `/health` が 200 を返すことをCIで確認

## 変更内容

- `ktse/src/main/kotlin/net/kigawa/keruta/ktse/KerutaTaskServer.kt`: `/health` エンドポイント追加
- `.github/workflows/ktse-check.yml`: `health-check` ジョブ追加（MySQL service → shadowJar ビルド → Docker イメージビルド → コンテナ起動 → ヘルスチェック）

## テスト計画

- [ ] CI の `health-check` ジョブが通過することを確認
- [ ] `curl http://localhost:8080/health` でローカル起動時も 200 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)