### PR TITLE
fix(ktcl-front): Dockerfile build-env に VITE_KISE_URL ARG を追加

### DIFF
--- a/.github/workflows/ktcl-front-dev.yml
+++ b/.github/workflows/ktcl-front-dev.yml
@@ -33,6 +33,7 @@ jobs:
               \"issuer\": \"https://ktcl-k8s-dev.kigawa.net\",
               \"description\": \"ktcl-k8s\"
             }
-          ]"
+          ]",
+          "VITE_KISE_URL": "https://kise-dev.kigawa.net"
         }
 

--- a/.github/workflows/ktcl-front-main.yml
+++ b/.github/workflows/ktcl-front-main.yml
@@ -33,6 +33,7 @@ jobs:
               \"issuer\": \"https://ktcl-k8s.kigawa.net\",
               \"description\": \"ktcl-k8s\"
             }
-          ]"
+          ]",
+          "VITE_KISE_URL": "https://kise.kigawa.net"
         }
 

--- a/.github/workflows/ktcl-front-stg.yml
+++ b/.github/workflows/ktcl-front-stg.yml
@@ -33,5 +33,6 @@ jobs:
               \"issuer\": \"https://ktcl-k8s-stg.kigawa.net\",
               \"description\": \"ktcl-k8s\"
             }
-          ]"
+          ]",
+          "VITE_KISE_URL": "https://kise-stg.kigawa.net"
         }

--- a/Dockerfile_ktcl_front
+++ b/Dockerfile_ktcl_front
@@ -17,6 +17,7 @@ ARG VITE_KEYCLOAK_URL
 ARG VITE_KEYCLOAK_REALM
 ARG VITE_KEYCLOAK_CLIENT_ID
 ARG VITE_PROVIDER_PRESETS
+ARG VITE_KISE_URL
 
 COPY ktcl-front /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules


### PR DESCRIPTION
## 概要
`Dockerfile_ktcl_front` のビルドステージに `VITE_KISE_URL` ビルド引数が欠落しており、Docker イメージ起動時に `Error: undefined env: kiseUrl` が発生していた問題を修正。

## 主な変更点
- `Dockerfile_ktcl_front` の build-env ステージに `ARG VITE_KISE_URL` を追加

## 影響範囲
- `ktcl-front` の Docker イメージビルド・起動

## 関連
- 直接的な関連 Issue/PR なし（起動エラーの緊急修正）