### PR TITLE
fix(ktcl-k8s): Java 25でのNetty起動失敗を修正（--enable-native-access）

### DIFF
--- a/Dockerfile_ktcl_k8s
+++ b/Dockerfile_ktcl_k8s
@@ -4,4 +4,4 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY ktcl-k8s/build/libs/ktcl-k8s.jar /app/app.jar
 WORKDIR /work
 ENTRYPOINT ["java"]
-CMD ["-jar","/app/app.jar"]
+CMD ["--enable-native-access=ALL-UNNAMED", "-jar","/app/app.jar"]


### PR DESCRIPTION
## 概要

- `Dockerfile_ktcl_k8s` に `--enable-native-access=ALL-UNNAMED` JVMフラグを追加

## 背景・原因

Java 25.0.3 (eclipse-temurin:25.0.3_9-jdk-noble) にアップグレード後、ktcl-k8s podがCrashLoopBackOffになっている。

調査の結果、HTTP サーバー（Ktor/Netty）がバインドされているにもかかわらず、kubeletのliveness/readiness probeが `/health` エンドポイントからEOFを受け取っていた。

これはNettyがJava 25の厳格なJNI/ネイティブアクセス制限によりネイティブライブラリのロードに失敗し、HTTPリクエストを処理できなくなっているためと推定される。

`--enable-native-access=ALL-UNNAMED` フラグはNetty（Java 25環境）での標準的な対処方法。

## テスト計画

- [ ] PRマージ後、CI/CDにより新しいDockerイメージがビルドされること
- [ ] ktcl-k8s podがCrashLoopBackOffから回復し、Running状態になること
- [ ] `/health` エンドポイントが正常に200 OKを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)