### PR TITLE
fix(ktcl-front): resolve crash loop by adding VITE_KISE_URL and improving config resilience

### DIFF
--- a/.github/workflows/ktcl-front-check.yml
+++ b/.github/workflows/ktcl-front-check.yml
@@ -22,5 +22,6 @@ jobs:
           "VITE_KEYCLOAK_URL": "https://example.com/",
           "VITE_KEYCLOAK_REALM": "test",
           "VITE_KEYCLOAK_CLIENT_ID": "test",
-          "VITE_PROVIDER_PRESETS": "[]"
+          "VITE_PROVIDER_PRESETS": "[]",
+          "VITE_KISE_URL": "http://localhost:8080"
         }

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -70,3 +70,14 @@ deployments:
             name: ktcl-front
             ports:
               - containerPort: 80
+            env:
+              - name: VITE_KISE_URL
+                value: https://kise-dev.kigawa.net
+              - name: VITE_WEBSOCKET_URL
+                value: wss://ktse-dev.kigawa.net/ws/ktcp
+              - name: USER_ISSUER
+                value: https://user.kigawa.net/realms/develop
+              - name: OWN_ISSUER
+                value: https://keruta-dev.kigawa.net
+              - name: KTSE_AUD
+                value: keruta

--- a/ktcl-front/app/Config.ts
+++ b/ktcl-front/app/Config.ts
@@ -1,8 +1,9 @@
 import {Url} from "./util/net/Url";
 
+const strWebsocketUrl = import.meta.env.VITE_WEBSOCKET_URL ?? process.env.VITE_WEBSOCKET_URL;
 const Config = {
-    websocketUrl: Url.parse(import.meta.env.VITE_WEBSOCKET_URL),
-    kiseUrl: import.meta.env.VITE_KISE_URL,
+    websocketUrl: strWebsocketUrl ? Url.parse(strWebsocketUrl) : undefined as unknown as Url,
+    kiseUrl: import.meta.env.VITE_KISE_URL ?? process.env.VITE_KISE_URL,
 } as const
 
 function validate() {


### PR DESCRIPTION
## Summary
Resolved the `CrashLoopBackOff` issue in `ktcl-front` caused by a missing `VITE_KISE_URL` environment variable.

## Changes
- **Application**: Modified `Config.ts` to support runtime `process.env` fallbacks, preventing crashes when build-time variables are missing.
- **ArgoCD**: Updated the deployment manifest in `kigawa-net-k8s` (via submodule commit) to include `VITE_KISE_URL`.
- **Workflows**: Added `VITE_KISE_URL` to `ktcl-front-check.yml` build arguments.
- **DevSpace**: Configured necessary environment variables in `devspace.yaml`.

## Verification
- Verified the root cause via container logs (`undefined env: kiseUrl`).
- Changes pushed to both the main repo and the k8s manifest repo.