### PR TITLE
fix(ktcl-k8s): KtclK8sServerをclassからobjectに戻す

### DIFF
--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/KtclK8sServer.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/KtclK8sServer.kt
@@ -4,7 +4,7 @@ import io.ktor.server.application.*
 import net.kigawa.keruta.ktcl.k8s.web.WebApplicationModule
 
 @Suppress("unused")
-class KtclK8sServer {
+object KtclK8sServer {
     private val webApplicationModule = WebApplicationModule()
     fun Application.module() {
         webApplicationModule.configure(this)


### PR DESCRIPTION
## 概要
`class KtclK8sServer` を `object KtclK8sServer` に戻す。classに変更されたことでKtorのモジュールローディングが機能せず、ヘルスチェックがEOFを返してCrashLoopBackOffが発生していた。

## 主な変更点
- `KtclK8sServer.kt`: `class` → `object` に変更

## 影響範囲
- `ktcl-k8s` モジュール（devクラスターのpod `ktcl-k8s` が正常起動するようになる）

## 関連
- Closes #382