### PR TITLE
feat(kicl-web): OIDC認可コードフロー（PKCE）によるログイン機能を実装

### DIFF
--- a/kicl-web/app/components/Nav.tsx
+++ b/kicl-web/app/components/Nav.tsx
@@ -1,6 +1,8 @@
 import {NavLink} from 'react-router';
+import {useAuth} from '../context/AuthContext';
 
 export function Nav() {
+    const {user, isLoading} = useAuth();
     const linkClass = ({isActive}: { isActive: boolean }) =>
         `text-sm ${isActive ? 'text-blue-600 font-medium' : 'text-gray-600 hover:text-gray-900'}`;
 
@@ -11,6 +13,11 @@ export function Nav() {
                 <NavLink to="/" className={linkClass} end>ホーム</NavLink>
                 <NavLink to="/account" className={linkClass}>アカウント</NavLink>
                 <NavLink to="/settings" className={linkClass}>設定</NavLink>
+                {!isLoading && user && (
+                    <span className="ml-auto text-sm text-gray-600">
+                        {user.profile.preferred_username ?? user.profile.email}
+                    </span>
+                )}
             </div>
         </nav>
     );

--- a/kicl-web/app/context/AuthContext.tsx
+++ b/kicl-web/app/context/AuthContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import type { User, UserManager } from 'oidc-client-ts';
+import { createUserManager } from '../lib/auth';
+import { SETTINGS_STORAGE_KEY, defaultSettings, type AppSettings } from '../types/settings';
+
+interface AuthContextType {
+    user: User | null;
+    isLoading: boolean;
+    login: () => void;
+    logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+    user: null,
+    isLoading: true,
+    login: () => {},
+    logout: () => {},
+});
+
+function loadSettings(): AppSettings {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    return stored ? { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) } : defaultSettings;
+}
+
+function buildManager(): UserManager | null {
+    const settings = loadSettings();
+    if (!settings.userIssuerUrl || !settings.oidcClientId) return null;
+    return createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [manager, setManager] = useState<UserManager | null>(null);
+
+    useEffect(() => {
+        const um = buildManager();
+        setManager(um);
+
+        if (!um) {
+            setIsLoading(false);
+            return;
+        }
+
+        um.getUser().then((u) => {
+            setUser(u);
+            setIsLoading(false);
+        });
+
+        const onLoaded = (u: User) => setUser(u);
+        const onUnloaded = () => setUser(null);
+        um.events.addUserLoaded(onLoaded);
+        um.events.addUserUnloaded(onUnloaded);
+
+        return () => {
+            um.events.removeUserLoaded(onLoaded);
+            um.events.removeUserUnloaded(onUnloaded);
+        };
+    }, []);
+
+    function login() {
+        if (!manager) {
+            window.location.href = '/settings';
+            return;
+        }
+        manager.signinRedirect();
+    }
+
+    function logout() {
+        if (!manager) return;
+        manager.signoutRedirect({ post_logout_redirect_uri: window.location.origin });
+    }
+
+    return (
+        <AuthContext.Provider value={{ user, isLoading, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth() {
+    return useContext(AuthContext);
+}

--- a/kicl-web/app/lib/auth.ts
+++ b/kicl-web/app/lib/auth.ts
@@ -1,0 +1,13 @@
+import { UserManager, WebStorageStateStore, type UserManagerSettings } from 'oidc-client-ts';
+
+export function createUserManager(issuerUrl: string, clientId: string): UserManager {
+    const settings: UserManagerSettings = {
+        authority: issuerUrl,
+        client_id: clientId,
+        redirect_uri: `${window.location.origin}/auth/callback`,
+        scope: 'openid profile email',
+        userStore: new WebStorageStateStore({ store: window.localStorage }),
+        automaticSilentRenew: false,
+    };
+    return new UserManager(settings);
+}

--- a/kicl-web/app/root.tsx
+++ b/kicl-web/app/root.tsx
@@ -1,6 +1,7 @@
 import {Links, Meta, Outlet, Scripts, ScrollRestoration} from "react-router";
 import "./index.css";
 import {Nav} from "./components/Nav";
+import {AuthProvider} from "./context/AuthContext";
 
 // noinspection JSUnusedGlobalSymbols
 export function Layout({children}: { children: React.ReactNode }) {
@@ -14,8 +15,10 @@ export function Layout({children}: { children: React.ReactNode }) {
                 <title>kicl</title>
             </head>
             <body className="min-h-screen min-w-screen">
-                <Nav/>
-                {children}
+                <AuthProvider>
+                    <Nav/>
+                    {children}
+                </AuthProvider>
                 <ScrollRestoration/>
                 <Scripts/>
             </body>

--- a/kicl-web/app/routes.tsx
+++ b/kicl-web/app/routes.tsx
@@ -5,4 +5,5 @@ export default [
     index("./routes/index.tsx"),
     route("settings", "./routes/settings.tsx"),
     route("account", "./routes/account.tsx"),
+    route("auth/callback", "./routes/auth.callback.tsx"),
 ] satisfies RouteConfig;

--- a/kicl-web/app/routes/account.tsx
+++ b/kicl-web/app/routes/account.tsx
@@ -1,113 +1,91 @@
-import {Form, useLoaderData, useNavigation} from 'react-router';
-import type {KeycloakProfile} from 'keycloak-js';
+import { Link } from 'react-router';
+import { useAuth } from '../context/AuthContext';
 
 export function HydrateFallback() {
     return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
 }
 
-interface AccountData {
-    userProfile: KeycloakProfile | null;
-    keycloakUrl: string;
-    keycloakRealm: string;
-}
-
-// Todo: サーバーサイドでKeycloak設定を読み込む実装に置き換え
-export async function clientLoader(): Promise<AccountData> {
-    // ブラウザサイドではlocalStorageまたはwindowからKeycloak設定を読み込む
-    const keycloakUrl = localStorage.getItem('keycloakUrl') ?? 'https://id.example.com';
-    const keycloakRealm = localStorage.getItem('keycloakRealm') ?? 'kigawa-net';
-
-    return {
-        userProfile: null, // Todo: 実際のKeycloakクライアントで読み込み
-        keycloakUrl,
-        keycloakRealm,
-    };
-}
-
-export async function clientAction({request}: {request: Request}): Promise<{success: boolean}> {
-    const formData = await request.formData();
-    const action = formData.get('_action');
-
-    if (action === 'logout') {
-        // Todo: Keycloakログアウトを実装
-        // ログアウト後にOIDCログエリダイレクトURIへリダイレクト
-        const redirectUri = window.location.origin;
-        window.location.href = `${redirectUri}/`;
-        return {success: true};
-    }
-
-    return {success: true};
-}
-
 export default function Account() {
-    const {userProfile, keycloakRealm} = useLoaderData() as AccountData;
-    const navigation = useNavigation();
-    const isSubmitting = navigation.state === 'submitting';
+    const { user, isLoading, login, logout } = useAuth();
+
+    if (isLoading) {
+        return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+    }
 
     return (
         <div className="max-w-2xl mx-auto p-8">
             <h1 className="text-2xl font-bold mb-6">アカウント</h1>
 
             <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-6">
-                <section>
-                    <h2 className="text-base font-semibold text-gray-700 mb-4">ユーザー情報</h2>
-                    {userProfile ? (
-                        <dl className="space-y-4">
-                            <div>
-                                <dt className="text-sm font-medium text-gray-500">ユーザー名</dt>
-                                <dd className="text-base text-gray-900">{userProfile.username ?? '-'}</dd>
-                            </div>
-                            <div>
-                                <dt className="text-sm font-medium text-gray-500">メールアドレス</dt>
-                                <dd className="text-base text-gray-900">{userProfile.email ?? '-'}</dd>
-                            </div>
-                            <div>
-                                <dt className="text-sm font-medium text-gray-500">氏名</dt>
-                                <dd className="text-base text-gray-900">
-                                    {userProfile.firstName && userProfile.lastName
-                                        ? `${userProfile.firstName} ${userProfile.lastName}`
-                                        : userProfile.firstName ?? userProfile.lastName ?? '-'}
-                                </dd>
-                            </div>
-                        </dl>
-                    ) : (
-                        <p className="text-sm text-gray-500">ユーザー情報がありません</p>
-                    )}
-                </section>
+                {user ? (
+                    <>
+                        <section>
+                            <h2 className="text-base font-semibold text-gray-700 mb-4">ユーザー情報</h2>
+                            <dl className="space-y-4">
+                                <div>
+                                    <dt className="text-sm font-medium text-gray-500">ユーザー名</dt>
+                                    <dd className="text-base text-gray-900">{user.profile.preferred_username ?? '-'}</dd>
+                                </div>
+                                <div>
+                                    <dt className="text-sm font-medium text-gray-500">メールアドレス</dt>
+                                    <dd className="text-base text-gray-900">{user.profile.email ?? '-'}</dd>
+                                </div>
+                                <div>
+                                    <dt className="text-sm font-medium text-gray-500">氏名</dt>
+                                    <dd className="text-base text-gray-900">
+                                        {user.profile.given_name && user.profile.family_name
+                                            ? `${user.profile.given_name} ${user.profile.family_name}`
+                                            : (user.profile.name ?? '-')}
+                                    </dd>
+                                </div>
+                            </dl>
+                        </section>
 
-                <section className="pt-4 border-t border-gray-200">
-                    <h2 className="text-base font-semibold text-gray-700 mb-4">認証情報</h2>
-                    <dl className="space-y-4">
-                        <div>
-                            <dt className="text-sm font-medium text-gray-500">認証プロバイダー</dt>
-                            <dd className="text-base text-gray-900">Keycloak</dd>
-                        </div>
-                        <div>
-                            <dt className="text-sm font-medium text-gray-500">Realm</dt>
-                            <dd className="text-base text-gray-900">{keycloakRealm}</dd>
-                        </div>
-                    </dl>
-                </section>
+                        <section className="pt-4 border-t border-gray-200">
+                            <h2 className="text-base font-semibold text-gray-700 mb-4">認証情報</h2>
+                            <dl className="space-y-4">
+                                <div>
+                                    <dt className="text-sm font-medium text-gray-500">発行者</dt>
+                                    <dd className="text-base text-gray-900 break-all">{user.profile.iss}</dd>
+                                </div>
+                            </dl>
+                        </section>
 
-                <section className="pt-4 border-t border-gray-200">
-                    <h2 className="text-base font-semibold text-gray-700 mb-4">アカウント操作</h2>
-                    <Form method="post">
-                        <input type="hidden" name="_action" value="logout" />
+                        <section className="pt-4 border-t border-gray-200">
+                            <h2 className="text-base font-semibold text-gray-700 mb-4">アカウント操作</h2>
+                            <button
+                                onClick={logout}
+                                className="block w-full rounded bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                            >
+                                ログアウト
+                            </button>
+                        </section>
+                    </>
+                ) : (
+                    <section>
+                        <h2 className="text-base font-semibold text-gray-700 mb-4">ログイン</h2>
+                        <p className="text-sm text-gray-500 mb-4">
+                            ログインするには以下のボタンをクリックしてください。
+                        </p>
                         <button
-                            type="submit"
-                            disabled={isSubmitting}
-                            className="block w-full rounded bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+                            onClick={login}
+                            className="block w-full rounded bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                         >
-                            {isSubmitting ? 'ログアウト中...' : 'ログアウト'}
+                            ログイン
                         </button>
-                    </Form>
-                </section>
+                        <p className="mt-4 text-xs text-gray-400">
+                            ※ OIDCプロバイダー URL とクライアント ID を事前に
+                            <Link to="/settings" className="text-blue-600 hover:underline">設定</Link>
+                            してください。
+                        </p>
+                    </section>
+                )}
             </div>
 
             <div className="mt-6 text-center">
-                <a href="/settings" className="text-sm text-blue-600 hover:text-blue-700 hover:underline">
+                <Link to="/settings" className="text-sm text-blue-600 hover:text-blue-700 hover:underline">
                     設定に戻る
-                </a>
+                </Link>
             </div>
         </div>
     );

--- a/kicl-web/app/routes/auth.callback.tsx
+++ b/kicl-web/app/routes/auth.callback.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'react-router';
+import { createUserManager } from '../lib/auth';
+import { SETTINGS_STORAGE_KEY, defaultSettings, type AppSettings } from '../types/settings';
+
+export function HydrateFallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">認証処理中...</div>;
+}
+
+export async function clientLoader(): Promise<never> {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    const settings: AppSettings = stored
+        ? { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) }
+        : defaultSettings;
+
+    if (!settings.userIssuerUrl || !settings.oidcClientId) {
+        throw redirect('/settings');
+    }
+
+    const userManager = createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+    await userManager.signinRedirectCallback();
+    throw redirect('/account');
+}
+
+export default function AuthCallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">認証処理中...</div>;
+}

--- a/kicl-web/app/routes/settings.tsx
+++ b/kicl-web/app/routes/settings.tsx
@@ -13,6 +13,7 @@ export async function clientAction({request}: { request: Request }): Promise<{ s
     const settings: AppSettings = {
         ownIssuerUrl: String(formData.get('ownIssuerUrl') ?? ''),
         userIssuerUrl: String(formData.get('userIssuerUrl') ?? ''),
+        oidcClientId: String(formData.get('oidcClientId') ?? ''),
         ktseUrl: String(formData.get('ktseUrl') ?? ''),
         language: (String(formData.get('language')) as AppSettings['language']) || 'ja',
     };
@@ -115,6 +116,12 @@ export default function Settings() {
                             name="userIssuerUrl"
                             defaultValue={settings.userIssuerUrl}
                             placeholder="https://oidc.example.com"
+                        />
+                        <Field
+                            label="OIDCクライアント ID"
+                            name="oidcClientId"
+                            defaultValue={settings.oidcClientId}
+                            placeholder="my-client"
                         />
                         <Field
                             label="タスクサーバー URL"

--- a/kicl-web/app/types/settings.ts
+++ b/kicl-web/app/types/settings.ts
@@ -3,6 +3,7 @@ export type Language = 'ja' | 'en';
 export interface AppSettings {
     ownIssuerUrl: string;
     userIssuerUrl: string;
+    oidcClientId: string;
     ktseUrl: string;
     language: Language;
 }
@@ -10,6 +11,7 @@ export interface AppSettings {
 export const defaultSettings: AppSettings = {
     ownIssuerUrl: '',
     userIssuerUrl: '',
+    oidcClientId: '',
     ktseUrl: '',
     language: 'ja',
 };

--- a/kicl-web/package-lock.json
+++ b/kicl-web/package-lock.json
@@ -14,6 +14,7 @@
                 "isbot": "^5",
                 "keruta-kicl-kicl-domain": "file:../kicl/kicl-domain/build/dist/js/productionLibrary",
                 "keruta-kicl-kicl-usecase": "file:../kicl/kicl-usecase/build/dist/js/productionLibrary",
+                "oidc-client-ts": "^3.5.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-router": "^7.11.0"
@@ -1666,9 +1667,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1684,9 +1682,6 @@
             "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1704,9 +1699,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1722,9 +1714,6 @@
             "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1742,9 +1731,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1760,9 +1746,6 @@
             "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2311,9 +2294,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2331,9 +2311,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2351,9 +2328,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "os": [
                 "linux"
@@ -2370,9 +2344,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4612,6 +4583,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/keruta-kicl-kicl-domain": {
             "resolved": "../kicl/kicl-domain/build/dist/js/productionLibrary",
             "link": true
@@ -5166,6 +5146,18 @@
                 "https://opencollective.com/debug"
             ],
             "license": "MIT"
+        },
+        "node_modules/oidc-client-ts": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+            "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jwt-decode": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/on-finished": {
             "version": "2.4.1",

--- a/kicl-web/package.json
+++ b/kicl-web/package.json
@@ -19,13 +19,14 @@
         "isbot": "^5",
         "keruta-kicl-kicl-domain": "file:../kicl/kicl-domain/build/dist/js/productionLibrary",
         "keruta-kicl-kicl-usecase": "file:../kicl/kicl-usecase/build/dist/js/productionLibrary",
+        "oidc-client-ts": "^3.5.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router": "^7.11.0"
     },
     "devDependencies": {
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
         "@eslint/js": "^10.0.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
         "@tailwindcss/vite": "^4.1.13",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## 概要
kicl-web に標準 OIDC 認可コードフロー（PKCE）を使ったログイン機能を追加しました。

## 主な変更点
- `oidc-client-ts` を追加し、任意の OIDC プロバイダーに対応する認可コードフロー（PKCE）を実装
- `app/context/AuthContext.tsx` を新規作成：React Context でログイン状態・login/logout 関数をアプリ全体に提供
- `app/lib/auth.ts` を新規作成：`UserManager` 生成ヘルパー
- `app/routes/auth.callback.tsx` を新規作成：`/auth/callback` ルートで認可コードを受け取りトークン交換
- `account.tsx` を更新：ログインボタン・ユーザープロフィール（username/email/氏名/発行者）表示・ログアウトボタンを実装
- `settings.tsx` と `settings.ts` を更新：`oidcClientId` フィールドを追加
- `Nav.tsx` を更新：ログイン済みユーザー名を右端に表示
- `root.tsx` を更新：`AuthProvider` で全体をラップ

## 影響範囲
- kicl-web フロントエンドのみ

## 利用方法
1. 設定画面で「OIDCプロバイダー URL」と「OIDCクライアント ID」を入力・保存
2. アカウント画面で「ログイン」ボタンをクリック → OIDC プロバイダーへリダイレクト
3. 認証後に `/auth/callback` 経由でトークン取得 → アカウント画面でプロフィール表示

## 関連
- Closes #384