### PR TITLE
fix(ktcl-k8s): Java 25.0.3+Netty 4.2.12でヘルスチェックEOFになる問題を修正

### DIFF
--- a/Dockerfile_ktcl_k8s
+++ b/Dockerfile_ktcl_k8s
@@ -1,7 +1,7 @@
-FROM eclipse-temurin:25.0.3_9-jdk-noble
+FROM eclipse-temurin:25.0.2_10-jdk-noble
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY ktcl-k8s/build/libs/ktcl-k8s.jar /app/app.jar
 WORKDIR /work
 ENTRYPOINT ["java"]
-CMD ["--enable-native-access=ALL-UNNAMED", "-jar","/app/app.jar"]
+CMD ["-jar","/app/app.jar"]


### PR DESCRIPTION
## 概要
Java 25.0.3 + Netty 4.2.12 + `--enable-native-access=ALL-UNNAMED`フラグの組み合わせでktcl-k8s PodがCrashLoopBackOffになる問題を修正する。

## 主な変更点
- `Dockerfile_ktcl_k8s`: Java 25.0.3 → 25.0.2へダウングレード
- `Dockerfile_ktcl_k8s`: `--enable-native-access=ALL-UNNAMED`フラグを削除

## 原因
Java 25.0.3 + Netty 4.2.12（Ktor 3.4.3経由）+ `--enable-native-access=ALL-UNNAMED`の組み合わせで、NettyがPanama FFM APIを通じてEpollネイティブトランスポートを初期化する際にバグが発生。アプリは起動するが、HTTPリクエストに対してEOFが返る。

**旧動作**: Java 25.0.2 + Ktor 3.4.1 + フラグなし → `java -jar /app/app.jar` → 正常  
**新失敗**: Java 25.0.3 + Ktor 3.4.3 + フラグあり → `java --enable-native-access=ALL-UNNAMED -jar /app/app.jar` → EOF

## 影響範囲
- `Dockerfile_ktcl_k8s`（ktcl-k8s全環境）

## 関連
- Closes #388