### PR TITLE
fix(ktcl-front-mobile): compose 1.11.0 へアップデートし iosX64 ターゲットを廃止

### DIFF
--- a/buildSrc/src/main/kotlin/compose-mobile-lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/compose-mobile-lib.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 kotlin {
     // iOS targets are configured by kmp plugin
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -36,11 +35,11 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation("org.jetbrains.compose.runtime:runtime:1.10.3")
-            implementation("org.jetbrains.compose.foundation:foundation:1.10.3")
+            implementation("org.jetbrains.compose.runtime:runtime:1.11.0")
+            implementation("org.jetbrains.compose.foundation:foundation:1.11.0")
             implementation("org.jetbrains.compose.material3:material3:1.9.0")
-            implementation("org.jetbrains.compose.ui:ui:1.10.3")
-            implementation("org.jetbrains.compose.components:components-resources:1.10.3")
+            implementation("org.jetbrains.compose.ui:ui:1.11.0")
+            implementation("org.jetbrains.compose.components:components-resources:1.11.0")
             // TODO: Re-enable when iOS compatibility is resolved
             // implementation("org.jetbrains.androidx.navigation:navigation-compose:2.8.0-alpha10")
             // implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")

--- a/buildSrc/src/main/kotlin/kmp.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp.gradle.kts
@@ -44,7 +44,6 @@ kotlin {
 
     // iOS targets for mobile support
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { _ ->


### PR DESCRIPTION
## 概要
compose-multiplatform 1.11.0 で \`components-resources\` の \`iosX64\` ターゲットサポートが廃止されたため、\`iosX64()\` を削除し、すべての compose コンポーネントを 1.11.0 に統一する。

## 主な変更点
- \`compose-mobile-lib.gradle.kts\` から \`iosX64()\` ターゲットを削除
- \`runtime\`, \`foundation\`, \`ui\`, \`components-resources\` を \`1.10.3\` → \`1.11.0\` に更新

## 影響範囲
- \`buildSrc/src/main/kotlin/compose-mobile-lib.gradle.kts\`
- \`ktcl-front-mobile\` モジュールの iOS ターゲット（iosArm64, iosSimulatorArm64 は継続）

## 関連
- Closes #401
- Closes renovate PR #376 (foundation 1.11.0)
- Closes renovate PR #377 (runtime 1.11.0)
- Closes renovate PR #378 (ui 1.11.0)
- 実装計画: PR #391