### PR TITLE
fix(ktcl-k8s): Netty バージョン競合解消のため Ktor サーバーエンジンを CIO に変更

### DIFF
--- a/ktcl-k8s/build.gradle.kts
+++ b/ktcl-k8s/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     // Ktor Server
     implementation("io.ktor:ktor-server-core-jvm:${Version.KTOR}")
-    implementation("io.ktor:ktor-server-netty:${Version.KTOR}")
+    implementation("io.ktor:ktor-server-cio:${Version.KTOR}")
     implementation("io.ktor:ktor-server-sessions:${Version.KTOR}")
     implementation("io.ktor:ktor-server-auth:${Version.KTOR}")
     implementation("io.ktor:ktor-server-content-negotiation:${Version.KTOR}")

--- a/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/Main.kt
+++ b/ktcl-k8s/src/main/kotlin/net/kigawa/keruta/ktcl/k8s/Main.kt
@@ -21,6 +21,6 @@ object Main {
     @JvmStatic
     fun main(args: Array<String>) {
         // EngineMainを使用してKtorサーバーを起動
-        io.ktor.server.netty.EngineMain.main(args)
+        io.ktor.server.cio.EngineMain.main(args)
     }
 }


### PR DESCRIPTION
## 概要
Kubernetes client 26.0.0 が引き込む AWS SDK の Netty 4.2.x と、Ktor Netty サーバー（Netty 4.1.x でコンパイル）の非互換により ktcl-k8s pod が8日間 CrashLoopBackOff となっていた問題を修正する。

## 主な変更点
- `ktcl-k8s/build.gradle.kts`: `ktor-server-netty` → `ktor-server-cio`
- `ktcl-k8s/src/main/kotlin/.../Main.kt`: `NettyEngineMain` → `CIOEngineMain`

## 根本原因
```
io.kubernetes:client-java:26.0.0
  → software.amazon.awssdk:netty-nio-client:2.42.22
    → io.netty:*:4.2.13.Final  (Ktor は 4.1.x でコンパイル)
```
Netty 4.1.x → 4.2.x は後方互換性なし。サーバー起動・DB接続は成功するが HTTP リクエスト処理が無応答となり、ヘルスプローブが EOF を返す。

## 影響範囲
- `ktcl-k8s` モジュールのみ（Ktor CIO はサーバー側の Netty 依存を除去する）

## 関連
- Closes #411