### PR TITLE
docs(convention): doc更新PRにdocumentationラベルを必須とする規約を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ PR作成前チェック:
 - [ ] CI（GitHub Actions）が全て通過していること
 - [ ] 1 PR = 1 機能（または 1 修正）の粒度であること
 - [ ] `Closes #<Issue番号>` で対応Issueを関連付けていること
+- [ ] `doc/` 配下の変更を含む場合は `documentation` ラベルを付与していること
 
 ---
 
@@ -461,6 +462,7 @@ docker build -f Dockerfile_ktcl_front -t harbor.kigawa.net/private/ktcl-front:la
 - [ ] 変更の粒度は適切か（1 PR = 1 機能/修正）
 - [ ] CIが全て通過しているか
 - [ ] `Closes #<Issue番号>` で対応Issueを関連付けているか
+- [ ] `doc/` 配下の変更を含む場合は `documentation` ラベルを付与しているか
 - [ ] [doc/convention/pull-request.md](doc/convention/pull-request.md) を確認済みか
 
 ### 参考ドキュメント

--- a/doc/convention/pull-request.md
+++ b/doc/convention/pull-request.md
@@ -197,14 +197,29 @@ PR を作成する前に、以下の項目を確認すること:
 
 必要に応じて以下のラベルを付与する:
 
-| ラベル | 用途 |
-|--------|------|
-| `bug` | バグ修正 |
-| `enhancement` | 新機能・機能拡張 |
-| `documentation` | ドキュメント関連 |
-| `refactoring` | リファクタリング |
-| `breaking-change` | 後方互換性のない変更 |
-| `dependencies` | 依存関係の更新 |
+| ラベル | 用途 | 付与タイミング |
+|--------|------|--------------|
+| `bug` | バグ修正 | 任意 |
+| `enhancement` | 新機能・機能拡張 | 任意 |
+| `documentation` | ドキュメント関連 | **`doc/` 配下の変更を含む PR には必須** |
+| `refactoring` | リファクタリング | 任意 |
+| `breaking-change` | 後方互換性のない変更 | 任意 |
+| `dependencies` | 依存関係の更新 | 任意 |
+
+**ドキュメントラベルの付与ルール:**
+
+`doc/` 配下のファイルを変更・追加・削除する PR には、必ず `documentation` ラベルを付与すること。
+
+```bash
+# PR作成時にラベルを付与する例
+gh pr create --base develop \
+  --label "documentation" \
+  --title "docs: ..." \
+  --body "..."
+
+# 既存PRへのラベル付与
+gh pr edit <PR番号> --add-label "documentation"
+```
 
 ### 8-2. プロジェクト
 


### PR DESCRIPTION
## 概要

`doc/` 配下の変更を含むPRには `documentation` ラベルの付与を必須とする規約を追加しました。

## 主な変更点

- **`doc/convention/pull-request.md`**
  - ラベル表に「付与タイミング」列を追加
  - `documentation` ラベルを `doc/` 変更PRに**必須**と明記
  - ラベル付与のコマンド例を追加（`gh pr create --label "documentation"` 等）

- **`CLAUDE.md`**
  - PR作成前チェックリスト（Step 8）に「`doc/` 変更時は `documentation` ラベルを付与」を追加
  - インラインチェックリストにも同項目を追加

## 影響範囲

- ドキュメントおよびCLAUDE.mdのみ（コード変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtrBfCxKKL8YmD4YXhAgxD)_