### PR TITLE
feat(kicl-web): 全ページにログイン必須の認証ガードを追加

### DIFF
--- a/kicl-web/app/context/AuthContext.tsx
+++ b/kicl-web/app/context/AuthContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { User, UserManager } from 'oidc-client-ts';
-import { createUserManager } from '../lib/auth';
-import { SETTINGS_STORAGE_KEY, defaultSettings, type AppSettings } from '../types/settings';
+import { createUserManager, loadSettings } from '../lib/auth';
 
 interface AuthContextType {
     user: User | null;
@@ -16,11 +15,6 @@ const AuthContext = createContext<AuthContextType>({
     login: () => {},
     logout: () => {},
 });
-
-function loadSettings(): AppSettings {
-    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
-    return stored ? { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) } : defaultSettings;
-}
 
 function buildManager(): UserManager | null {
     const settings = loadSettings();

--- a/kicl-web/app/lib/auth.ts
+++ b/kicl-web/app/lib/auth.ts
@@ -1,4 +1,6 @@
+import { redirect } from 'react-router';
 import { UserManager, WebStorageStateStore, type UserManagerSettings } from 'oidc-client-ts';
+import { SETTINGS_STORAGE_KEY, defaultSettings, type AppSettings } from '../types/settings';
 
 export function createUserManager(issuerUrl: string, clientId: string): UserManager {
     const settings: UserManagerSettings = {
@@ -10,4 +12,23 @@ export function createUserManager(issuerUrl: string, clientId: string): UserMana
         automaticSilentRenew: false,
     };
     return new UserManager(settings);
+}
+
+export function loadSettings(): AppSettings {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    return stored ? { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) } : defaultSettings;
+}
+
+/** 認証が必要なルートのclientLoaderで使用する。未設定→/settings、未認証→/loginにリダイレクト */
+export async function requireAuth(): Promise<{ userManager: UserManager }> {
+    const settings = loadSettings();
+    if (!settings.userIssuerUrl || !settings.oidcClientId) {
+        throw redirect('/settings');
+    }
+    const userManager = createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+    const user = await userManager.getUser();
+    if (!user || user.expired) {
+        throw redirect('/login');
+    }
+    return { userManager };
 }

--- a/kicl-web/app/lib/auth.ts
+++ b/kicl-web/app/lib/auth.ts
@@ -16,19 +16,28 @@ export function createUserManager(issuerUrl: string, clientId: string): UserMana
 
 export function loadSettings(): AppSettings {
     const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
-    return stored ? { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) } : defaultSettings;
+    if (!stored) return defaultSettings;
+    try {
+        return { ...defaultSettings, ...(JSON.parse(stored) as Partial<AppSettings>) };
+    } catch {
+        return defaultSettings;
+    }
 }
 
-/** 認証が必要なルートのclientLoaderで使用する。未設定→/settings、未認証→/loginにリダイレクト */
-export async function requireAuth(): Promise<{ userManager: UserManager }> {
+/** 設定済みのUserManagerを返す。未設定の場合は/settingsにリダイレクト */
+export function getConfiguredUserManager(): UserManager {
     const settings = loadSettings();
     if (!settings.userIssuerUrl || !settings.oidcClientId) {
         throw redirect('/settings');
     }
-    const userManager = createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+    return createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+}
+
+/** 認証が必要なルートのclientLoaderで使用する。未設定→/settings、未認証→/loginにリダイレクト */
+export async function requireAuth(): Promise<void> {
+    const userManager = getConfiguredUserManager();
     const user = await userManager.getUser();
     if (!user || user.expired) {
         throw redirect('/login');
     }
-    return { userManager };
 }

--- a/kicl-web/app/routes.tsx
+++ b/kicl-web/app/routes.tsx
@@ -3,6 +3,7 @@ import {index, route, type RouteConfig} from "@react-router/dev/routes";
 // noinspection JSUnusedGlobalSymbols
 export default [
     index("./routes/index.tsx"),
+    route("login", "./routes/login.tsx"),
     route("settings", "./routes/settings.tsx"),
     route("account", "./routes/account.tsx"),
     route("auth/callback", "./routes/auth.callback.tsx"),

--- a/kicl-web/app/routes/account.tsx
+++ b/kicl-web/app/routes/account.tsx
@@ -1,14 +1,24 @@
 import { Link } from 'react-router';
 import { useAuth } from '../context/AuthContext';
+import { requireAuth } from '../lib/auth';
 
 export function HydrateFallback() {
     return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
 }
 
+export async function clientLoader(): Promise<null> {
+    await requireAuth();
+    return null;
+}
+
 export default function Account() {
-    const { user, isLoading, login, logout } = useAuth();
+    const { user, isLoading, logout } = useAuth();
 
     if (isLoading) {
+        return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+    }
+
+    if (!user) {
         return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
     }
 
@@ -17,74 +27,52 @@ export default function Account() {
             <h1 className="text-2xl font-bold mb-6">アカウント</h1>
 
             <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-6">
-                {user ? (
-                    <>
-                        <section>
-                            <h2 className="text-base font-semibold text-gray-700 mb-4">ユーザー情報</h2>
-                            <dl className="space-y-4">
-                                <div>
-                                    <dt className="text-sm font-medium text-gray-500">ユーザー名</dt>
-                                    <dd className="text-base text-gray-900">{user.profile.preferred_username ?? '-'}</dd>
-                                </div>
-                                <div>
-                                    <dt className="text-sm font-medium text-gray-500">メールアドレス</dt>
-                                    <dd className="text-base text-gray-900">{user.profile.email ?? '-'}</dd>
-                                </div>
-                                <div>
-                                    <dt className="text-sm font-medium text-gray-500">氏名</dt>
-                                    <dd className="text-base text-gray-900">
-                                        {user.profile.given_name && user.profile.family_name
-                                            ? `${user.profile.given_name} ${user.profile.family_name}`
-                                            : (user.profile.name ?? '-')}
-                                    </dd>
-                                </div>
-                            </dl>
-                        </section>
+                <section>
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">ユーザー情報</h2>
+                    <dl className="space-y-4">
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">ユーザー名</dt>
+                            <dd className="text-base text-gray-900">{user.profile.preferred_username ?? '-'}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">メールアドレス</dt>
+                            <dd className="text-base text-gray-900">{user.profile.email ?? '-'}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">氏名</dt>
+                            <dd className="text-base text-gray-900">
+                                {user.profile.given_name && user.profile.family_name
+                                    ? `${user.profile.given_name} ${user.profile.family_name}`
+                                    : (user.profile.name ?? '-')}
+                            </dd>
+                        </div>
+                    </dl>
+                </section>
 
-                        <section className="pt-4 border-t border-gray-200">
-                            <h2 className="text-base font-semibold text-gray-700 mb-4">認証情報</h2>
-                            <dl className="space-y-4">
-                                <div>
-                                    <dt className="text-sm font-medium text-gray-500">発行者</dt>
-                                    <dd className="text-base text-gray-900 break-all">{user.profile.iss}</dd>
-                                </div>
-                            </dl>
-                        </section>
+                <section className="pt-4 border-t border-gray-200">
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">認証情報</h2>
+                    <dl className="space-y-4">
+                        <div>
+                            <dt className="text-sm font-medium text-gray-500">発行者</dt>
+                            <dd className="text-base text-gray-900 break-all">{user.profile.iss}</dd>
+                        </div>
+                    </dl>
+                </section>
 
-                        <section className="pt-4 border-t border-gray-200">
-                            <h2 className="text-base font-semibold text-gray-700 mb-4">アカウント操作</h2>
-                            <button
-                                onClick={logout}
-                                className="block w-full rounded bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
-                            >
-                                ログアウト
-                            </button>
-                        </section>
-                    </>
-                ) : (
-                    <section>
-                        <h2 className="text-base font-semibold text-gray-700 mb-4">ログイン</h2>
-                        <p className="text-sm text-gray-500 mb-4">
-                            ログインするには以下のボタンをクリックしてください。
-                        </p>
-                        <button
-                            onClick={login}
-                            className="block w-full rounded bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                            ログイン
-                        </button>
-                        <p className="mt-4 text-xs text-gray-400">
-                            ※ OIDCプロバイダー URL とクライアント ID を事前に
-                            <Link to="/settings" className="text-blue-600 hover:underline">設定</Link>
-                            してください。
-                        </p>
-                    </section>
-                )}
+                <section className="pt-4 border-t border-gray-200">
+                    <h2 className="text-base font-semibold text-gray-700 mb-4">アカウント操作</h2>
+                    <button
+                        onClick={logout}
+                        className="block w-full rounded bg-red-600 px-5 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                    >
+                        ログアウト
+                    </button>
+                </section>
             </div>
 
             <div className="mt-6 text-center">
                 <Link to="/settings" className="text-sm text-blue-600 hover:text-blue-700 hover:underline">
-                    設定に戻る
+                    設定
                 </Link>
             </div>
         </div>

--- a/kicl-web/app/routes/account.tsx
+++ b/kicl-web/app/routes/account.tsx
@@ -18,9 +18,7 @@ export default function Account() {
         return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
     }
 
-    if (!user) {
-        return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
-    }
+    if (!user) return null;
 
     return (
         <div className="max-w-2xl mx-auto p-8">

--- a/kicl-web/app/routes/index.tsx
+++ b/kicl-web/app/routes/index.tsx
@@ -1,11 +1,21 @@
-import {KiclDomain} from "keruta-kicl-kicl-domain";
+import { KiclDomain } from 'keruta-kicl-kicl-domain';
+import { requireAuth } from '../lib/auth';
+
+export function HydrateFallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+}
+
+export async function clientLoader(): Promise<null> {
+    await requireAuth();
+    return null;
+}
 
 export default function Index() {
     const version = KiclDomain.getInstance().VERSION;
     return (
-        <div>
-            <h1>kicl</h1>
-            <p>version: {version}</p>
+        <div className="max-w-2xl mx-auto p-8">
+            <h1 className="text-2xl font-bold mb-4">kicl</h1>
+            <p className="text-sm text-gray-600">バージョン: {version}</p>
         </div>
     );
 }

--- a/kicl-web/app/routes/login.tsx
+++ b/kicl-web/app/routes/login.tsx
@@ -1,0 +1,41 @@
+import { redirect } from 'react-router';
+import { createUserManager, loadSettings } from '../lib/auth';
+import { useAuth } from '../context/AuthContext';
+
+export function HydrateFallback() {
+    return <div className="max-w-2xl mx-auto p-8 text-gray-500 text-sm">読み込み中...</div>;
+}
+
+export async function clientLoader(): Promise<null> {
+    const settings = loadSettings();
+    if (!settings.userIssuerUrl || !settings.oidcClientId) {
+        throw redirect('/settings');
+    }
+    const userManager = createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+    const user = await userManager.getUser();
+    if (user && !user.expired) {
+        throw redirect('/');
+    }
+    return null;
+}
+
+export default function Login() {
+    const { login } = useAuth();
+
+    return (
+        <div className="flex min-h-[60vh] items-center justify-center">
+            <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+                <h1 className="mb-2 text-2xl font-bold text-gray-900">kicl</h1>
+                <p className="mb-6 text-sm text-gray-500">
+                    このページにアクセスするにはログインが必要です。
+                </p>
+                <button
+                    onClick={login}
+                    className="w-full rounded bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                    ログイン
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/kicl-web/app/routes/login.tsx
+++ b/kicl-web/app/routes/login.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'react-router';
-import { createUserManager, loadSettings } from '../lib/auth';
+import { getConfiguredUserManager } from '../lib/auth';
 import { useAuth } from '../context/AuthContext';
 
 export function HydrateFallback() {
@@ -7,11 +7,7 @@ export function HydrateFallback() {
 }
 
 export async function clientLoader(): Promise<null> {
-    const settings = loadSettings();
-    if (!settings.userIssuerUrl || !settings.oidcClientId) {
-        throw redirect('/settings');
-    }
-    const userManager = createUserManager(settings.userIssuerUrl, settings.oidcClientId);
+    const userManager = getConfiguredUserManager();
     const user = await userManager.getUser();
     if (user && !user.expired) {
         throw redirect('/');

--- a/kicl-web/package-lock.json
+++ b/kicl-web/package-lock.json
@@ -1667,9 +1667,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1685,9 +1682,6 @@
             "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1705,9 +1699,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1723,9 +1714,6 @@
             "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1743,9 +1731,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1761,9 +1746,6 @@
             "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,


### PR DESCRIPTION
## 概要

PR #413 のドキュメント「kicl-webは全ページでログインが必須」に合わせて認証ガードを実装しました。

## 主な変更点

- `app/lib/auth.ts`: `loadSettings` / `requireAuth` ヘルパーを追加
  - 未設定時 → `/settings` にリダイレクト
  - 未認証時 → `/login` にリダイレクト
- `app/routes/login.tsx`: 専用ログインページを新設
- `app/routes/index.tsx`: `clientLoader` で認証ガードを追加
- `app/routes/account.tsx`: `clientLoader` で認証ガードを追加、未認証時のログインUIを削除
- `app/routes.tsx`: `/login` ルートを登録

## 認証フロー

```
未認証ユーザーが任意のページへアクセス
  → clientLoader の requireAuth() が実行
  → 設定未完了 → /settings にリダイレクト
  → 未認証 → /login にリダイレクト
  → /login でログインボタン押下 → OIDC signinRedirect
  → /auth/callback で完了 → /account へリダイレクト
```

## 影響範囲

- `kicl-web` のルーティング・認証ガード
- `settings` および `auth/callback` は認証不要のまま維持

## 関連

- Closes に対応するドキュメントPR: #413

https://claude.ai/code/session_01FZZGjJzioBxm5Jr4ykhnk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZZGjJzioBxm5Jr4ykhnk9)_